### PR TITLE
security: Remove link to deleted spec

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -40,8 +40,3 @@ The architecture is seen in the diagram below.
 
 The idea here is that DPU and IPU vendors will implement strongSwan plugins to
 offload the tunnels into hardware.
-
-## OPI Security API Spec
-
-The [Security Spec](security-spec.md) is the best place for up to date information on the OPI
-Security API.


### PR DESCRIPTION
Commit 9bd55a5 removed the security spec, but forgot to remove the link
from the README.md file. This fixes that.

Signed-off-by: Kyle Mestery <mestery@mestery.com>