### PR TITLE
storage: Unify front-end block APIs

### DIFF
--- a/storage/v1/common.proto
+++ b/storage/v1/common.proto
@@ -6,22 +6,13 @@ syntax = "proto3";
 package opi_api.storage.v1;
 option go_package = "github.com/opiproject/opi-api/storage/v1/gen/go";
 
-// The controller PCI-ID is used to address a given virtual controller. Virtual
-// controllers are organized into devices with Physical functions and SRIOV
-// virtual function within the physical functions. Currently, xPUs may
-// expose multiple devices with one physical function each and one or more
-// virtual functions under the physical function.
-message NvmeControllerPciId {
-    // Bus number, provided for future usage if needed. Currently set to ’0’
-    uint32 bus              = 1;
-
-    // Device number, based on the NVMe device layout
-    uint32 device           = 2;
-
-    // Physical function, always set to 0 in current model
-    uint32 function         = 3;
-
-    // SRIOV Virtual function within the Device and Physical function.
-    // Set to 0 for Physical Function. Virtual Function numbering starts from 1
-    uint32 virtual_function  = 4;
+// Many front-ends expose PCI devices to the host. This represents that endpoint.
+// The Bus:Device:Function numbers will be assigned by the OS PCI driver, so we
+// cannot set those directly here. What we can pick is which physical function
+// and virtual function the xPU uses.
+message PciEndpoint {
+    // Physical function index
+    uint32 physical_id = 1;
+    // Virtual function index
+    uint32 virtual_id = 2;
 }

--- a/storage/v1/frontend_nvme_pcie.proto
+++ b/storage/v1/frontend_nvme_pcie.proto
@@ -40,25 +40,14 @@ message NVMeSubsystem {
     // object's unique identifier
     common.v1.ObjectKey id = 1;
 
-    // NVMe subsystem NQN to which the controller belongs
-    // Refer to the NQN format in the NVMe base specifications, must not
-    // exceed 'NSV_NVME_SUBSYSTEM_NQN_LEN' bytes
-    string nqn = 2;
-
     // serial number must not exceed 'NSV_CTRLR_SERIAL_NO_LEN' bytes
-    string serial_number = 3;
+    string serial_number = 2;
 
     // model number, must not exceed 'NSV_CTRLR_MODEL_NO_LEN' bytes
-    string model_number = 4;
+    string model_number = 3;
 
     // maximum namespaces within a subsystem
-    int64 max_ns = 5;
-
-    // firmware revision, must not exceed 'NSV_CTRLR_FW_REV_LEN'
-    string firmware_revision  = 6;
-
-    // FRU identfier, 16bytes opaque identity for the type of unit
-    bytes fru_guid = 7;
+    int32 max_ns = 4;
 }
 
 message NVMeController {
@@ -69,70 +58,35 @@ message NVMeController {
     // must not be reused under the same subsystem
     uint32 nvme_controller_id  = 2;
 
-    // subsystem information
-    common.v1.ObjectKey subsystem_id = 3;
-
     // xPU's PCI ID for the controller
-    PciEndpoint pcie_id = 4;
+    PciEndpoint pcie_id = 3;
 
     // maximum host IO queue pairs allowed, value will default to
     // limits in PCI device configuration; if set to 0 or more it
     // will default to maximum permitted per xPU's capability
-    uint32 max_io_qps = 5;
+    uint32 max_io_qps = 4;
 
     // maximum Number of namespaces that will be provisioned under
     // the controller.
-    uint32 max_ns = 6;
+    uint32 max_ns = 5;
 }
 
 message NVMeNamespace {
     // namespace's unique key
-    // replaces: int64 id = 1;
     common.v1.ObjectKey id = 1;
 
-    // subsystem for this namespace
-    common.v1.ObjectKey subsystem_id = 2;
-
-    // key of the PCIe controller object that will host this namespace.
-    common.v1.ObjectKey controller_id = 3;
-
-    // NSID present to the host by the NVMe PCIe controller.
-    // If not provided, then the controller will assign an unused NSID
-    // within the max namespace range - auto assigned nsid may not work
-    // for live migration
-    uint32 host_nsid = 4;
-
-    // Block size in bytes, must be power of 2 and must be less than the max
-    // io size supported. Typically tested values are 512, and 4k.
-    int64 block_size = 5;
-
-    // Size/Capacity of the namespace in blocks, size in bytes will
-    // be BlockSize x NumBlocks.
-    int64 num_blocks = 6;
-
     // Globally unique identifier for the namespace
-    string nguid = 7;
+    string nguid = 2;
 
     // 64bit Extended unique identifier for the namespace
     // mandatory if guid is not specified, optional otherwise
-    fixed64 eui64 = 8;
+    fixed64 eui64 = 3;
 
     // Globally unique identifier for the namespace
-    common.v1.Uuid uuid = 9;
+    common.v1.Uuid uuid = 4;
 
-    // reference to encryption key for the data at rest encryption
-    common.v1.ObjectKey crypto_key_id = 10;
-
-    // optimal write size hint to host driver. Host IO stack may use
-    // this to regulate IO size. Must be a multiple of the preferred write
-    // granularity. Must not exceed the controller maximum IO size value
-    // configured in the nvme agent config file.
-    uint32 optimal_write_size = 11;
-
-    // preferred write granularity hint to the host driver. Host IO
-    // stack may use this to align IO sizes to the write granularity for
-    // optimum performance.
-    uint32 pref_write_granularity= 12;
+    // The back/middle-end volume to back this namespace.
+    common.v1.ObjectKey volume_id = 5;
 }
 
 message NVMeSubsystemCreateRequest {
@@ -185,6 +139,9 @@ message NVMeSubsystemStatsResponse {
 
 message NVMeControllerCreateRequest {
     NVMeController controller = 1;
+
+    // The subsystem to associate this controller with
+    common.v1.ObjectKey subsystem_id = 2;
 }
 
 message NVMeControllerCreateResponse {
@@ -234,6 +191,12 @@ message NVMeControllerStatsResponse {
 
 message NVMeNamespaceCreateRequest {
     NVMeNamespace namespace = 1;
+
+    common.v1.ObjectKey subsystem_id = 2;
+
+    // The namespace ID inside of the subsystem where this namespace
+    // can be found.
+    uint32 nsid = 3;
 }
 
 message NVMeNamespaceCreateResponse {
@@ -257,8 +220,11 @@ message NVMeNamespaceUpdateResponse {
 }
 
 message NVMeNamespaceListRequest {
-    common.v1.ObjectKey subsystem_id = 1;
-    common.v1.ObjectKey controller_id = 2;
+    oneof view {
+        common.v1.ObjectKey subsystem_id = 1;
+
+        common.v1.ObjectKey controller_id = 2;
+    }
 }
 
 message NVMeNamespaceListResponse {

--- a/storage/v1/frontend_nvme_pcie.proto
+++ b/storage/v1/frontend_nvme_pcie.proto
@@ -13,25 +13,21 @@ import "object_key.proto";
 
 // NVMe/PCIe emulation
 
-service NVMeSubsystemService {
+service FrontendNvme {
     rpc NVMeSubsystemCreate (NVMeSubsystemCreateRequest) returns (NVMeSubsystemCreateResponse) {}
     rpc NVMeSubsystemDelete (NVMeSubsystemDeleteRequest) returns (NVMeSubsystemDeleteResponse) {}
     rpc NVMeSubsystemUpdate (NVMeSubsystemUpdateRequest) returns (NVMeSubsystemUpdateResponse) {}
     rpc NVMeSubsystemList   (NVMeSubsystemListRequest)   returns (NVMeSubsystemListResponse)   {}
     rpc NVMeSubsystemGet    (NVMeSubsystemGetRequest)    returns (NVMeSubsystemGetResponse)    {}
     rpc NVMeSubsystemStats  (NVMeSubsystemStatsRequest)  returns (NVMeSubsystemStatsResponse)  {}
-}
 
-service NVMeControllerService {
     rpc NVMeControllerCreate (NVMeControllerCreateRequest) returns (NVMeControllerCreateResponse) {}
     rpc NVMeControllerDelete (NVMeControllerDeleteRequest) returns (NVMeControllerDeleteResponse) {}
     rpc NVMeControllerUpdate (NVMeControllerUpdateRequest) returns (NVMeControllerUpdateResponse) {}
     rpc NVMeControllerList   (NVMeControllerListRequest)   returns (NVMeControllerListResponse)   {}
     rpc NVMeControllerGet    (NVMeControllerGetRequest)    returns (NVMeControllerGetResponse)    {}
     rpc NVMeControllerStats  (NVMeControllerStatsRequest)  returns (NVMeControllerStatsResponse)  {}
-}
 
-service NVMeNamespaceService {
     rpc NVMeNamespaceCreate (NVMeNamespaceCreateRequest) returns (NVMeNamespaceCreateResponse) {}
     rpc NVMeNamespaceDelete (NVMeNamespaceDeleteRequest) returns (NVMeNamespaceDeleteResponse) {}
     rpc NVMeNamespaceUpdate (NVMeNamespaceUpdateRequest) returns (NVMeNamespaceUpdateResponse) {}

--- a/storage/v1/frontend_nvme_pcie.proto
+++ b/storage/v1/frontend_nvme_pcie.proto
@@ -77,7 +77,7 @@ message NVMeController {
     common.v1.ObjectKey subsystem_id = 3;
 
     // xPU's PCI ID for the controller
-    NvmeControllerPciId pcie_id = 4;
+    PciEndpoint pcie_id = 4;
 
     // maximum host IO queue pairs allowed, value will default to
     // limits in PCI device configuration; if set to 0 or more it

--- a/storage/v1/frontend_virtio_blk.proto
+++ b/storage/v1/frontend_virtio_blk.proto
@@ -22,7 +22,7 @@ service VirtioBlkService {
 message VirtioBlk {
     int64 id = 1;
     string name = 2;
-    NvmeControllerPciId pcie_id = 3;
+    PciEndpoint pcie_id = 3;
     string bdev = 4;
     int64 max_io_qps = 5;
     string serial_number = 6;

--- a/storage/v1/frontend_virtio_blk.proto
+++ b/storage/v1/frontend_virtio_blk.proto
@@ -5,12 +5,13 @@ syntax = "proto3";
 package opi_api.storage.v1;
 option go_package = "github.com/opiproject/opi-api/storage/v1/gen/go";
 import "common.proto";
+import "object_key.proto";
 
 // Front End (host-facing) APIs.
 
 // Virtio-blk emulation
 
-service VirtioBlkService {
+service FrontendVirtioBlk {
     rpc VirtioBlkCreate (VirtioBlkCreateRequest) returns (VirtioBlkCreateResponse) {}
     rpc VirtioBlkDelete (VirtioBlkDeleteRequest) returns (VirtioBlkDeleteResponse) {}
     rpc VirtioBlkUpdate (VirtioBlkUpdateRequest) returns (VirtioBlkUpdateResponse) {}
@@ -19,17 +20,22 @@ service VirtioBlkService {
     rpc VirtioBlkStats  (VirtioBlkStatsRequest)  returns (VirtioBlkStatsResponse)  {}
 }
 
-message VirtioBlk {
-    int64 id = 1;
-    string name = 2;
-    PciEndpoint pcie_id = 3;
-    string bdev = 4;
-    int64 max_io_qps = 5;
-    string serial_number = 6;
+message VirtioBlkController {
+    common.v1.ObjectKey id = 1;
+
+    // The PCI endpoint where this device should appear
+    PciEndpoint pcie_id = 2;
+
+    // The back/middle-end volume to back this controller.
+    common.v1.ObjectKey volume_id = 3;
+
+    int64 max_io_qps = 4;
+
+    string serial_number = 5;
 }
 
 message VirtioBlkCreateRequest {
-    VirtioBlk controller = 1;
+    VirtioBlkController controller = 1;
 }
 
 message VirtioBlkCreateResponse {
@@ -37,7 +43,7 @@ message VirtioBlkCreateResponse {
 }
 
 message VirtioBlkDeleteRequest {
-    int64 controller_id = 1;
+    common.v1.ObjectKey id = 1;
 }
 
 message VirtioBlkDeleteResponse {
@@ -45,7 +51,7 @@ message VirtioBlkDeleteResponse {
 }
 
 message VirtioBlkUpdateRequest {
-    VirtioBlk controller = 1;
+    VirtioBlkController controller = 1;
 }
 
 message VirtioBlkUpdateResponse {
@@ -53,26 +59,26 @@ message VirtioBlkUpdateResponse {
 }
 
 message VirtioBlkListRequest {
-    int64 subsystem_id = 1;
+    // Intentionally empty.
 }
 
 message VirtioBlkListResponse {
-    repeated VirtioBlk controller = 1;
+    repeated VirtioBlkController controller = 1;
 }
 
 message VirtioBlkGetRequest {
-    int64 controller_id = 1;
+    common.v1.ObjectKey id = 1;
 }
 
 message VirtioBlkGetResponse {
-    VirtioBlk controller = 1;
+    VirtioBlkController controller = 1;
 }
 
 message VirtioBlkStatsRequest {
-    int64 controller_id = 1;
+    common.v1.ObjectKey id = 1;
 }
 
 message VirtioBlkStatsResponse {
-    int64 id = 1;
+    common.v1.ObjectKey id = 1;
     string stats = 2;
 }

--- a/storage/v1/frontend_virtio_scsi.proto
+++ b/storage/v1/frontend_virtio_scsi.proto
@@ -31,7 +31,7 @@ service VirtioScsiLunService {
 message VirtioScsiController {
     int64 id = 1;
     string name = 2;
-    NvmeControllerPciId pcie_id = 4;
+    PciEndpoint pcie_id = 3;
 }
 
 message VirtioScsiLun {

--- a/storage/v1/frontend_virtio_scsi.proto
+++ b/storage/v1/frontend_virtio_scsi.proto
@@ -5,21 +5,27 @@ syntax = "proto3";
 package opi_api.storage.v1;
 option go_package = "github.com/opiproject/opi-api/storage/v1/gen/go";
 import "common.proto";
+import "object_key.proto";
 
 // Front End (host-facing) APIs.
 
 // Virtio-scsi emulation
 
-service VirtioScsiControllerService {
+service FrontendVirtioScsi {
+    rpc VirtioScsiTargetCreate (VirtioScsiTargetCreateRequest) returns (VirtioScsiTargetCreateResponse) {}
+    rpc VirtioScsiTargetDelete (VirtioScsiTargetDeleteRequest) returns (VirtioScsiTargetDeleteResponse) {}
+    rpc VirtioScsiTargetUpdate (VirtioScsiTargetUpdateRequest) returns (VirtioScsiTargetUpdateResponse) {}
+    rpc VirtioScsiTargetList   (VirtioScsiTargetListRequest)   returns (VirtioScsiTargetListResponse)   {}
+    rpc VirtioScsiTargetGet    (VirtioScsiTargetGetRequest)    returns (VirtioScsiTargetGetResponse)    {}
+    rpc VirtioScsiTargetStats  (VirtioScsiTargetStatsRequest)  returns (VirtioScsiTargetStatsResponse)  {}
+
     rpc VirtioScsiControllerCreate (VirtioScsiControllerCreateRequest) returns (VirtioScsiControllerCreateResponse) {}
     rpc VirtioScsiControllerDelete (VirtioScsiControllerDeleteRequest) returns (VirtioScsiControllerDeleteResponse) {}
     rpc VirtioScsiControllerUpdate (VirtioScsiControllerUpdateRequest) returns (VirtioScsiControllerUpdateResponse) {}
     rpc VirtioScsiControllerList   (VirtioScsiControllerListRequest)   returns (VirtioScsiControllerListResponse)   {}
     rpc VirtioScsiControllerGet    (VirtioScsiControllerGetRequest)    returns (VirtioScsiControllerGetResponse)    {}
     rpc VirtioScsiControllerStats  (VirtioScsiControllerStatsRequest)  returns (VirtioScsiControllerStatsResponse)  {}
-}
 
-service VirtioScsiLunService {
     rpc VirtioScsiLunCreate (VirtioScsiLunCreateRequest) returns (VirtioScsiLunCreateResponse) {}
     rpc VirtioScsiLunDelete (VirtioScsiLunDeleteRequest) returns (VirtioScsiLunDeleteResponse) {}
     rpc VirtioScsiLunUpdate (VirtioScsiLunUpdateRequest) returns (VirtioScsiLunUpdateResponse) {}
@@ -28,20 +34,83 @@ service VirtioScsiLunService {
     rpc VirtioScsiLunStats  (VirtioScsiLunStatsRequest)  returns (VirtioScsiLunStatsResponse)  {}
 }
 
+message VirtioScsiTarget {
+    // object's unique identifier
+    common.v1.ObjectKey id = 1;
+
+    // maximum LUNs within a target
+    int32 max_ns = 3;
+}
+
 message VirtioScsiController {
-    int64 id = 1;
-    string name = 2;
+    // object's unique identifier
+    common.v1.ObjectKey id = 1;
+
+    // xPU's PCI ID for the controller
     PciEndpoint pcie_id = 3;
 }
 
 message VirtioScsiLun {
-    int64 id = 1;
-    int64 controller_id = 4;
-    string bdev = 6;
+    // object's unique identifier
+    common.v1.ObjectKey id = 1;
+
+    // The back/middle-end volume to back this LUN.
+    common.v1.ObjectKey volume_id = 5;
+}
+
+message VirtioScsiTargetCreateRequest {
+    VirtioScsiTarget target = 1;
+}
+
+message VirtioScsiTargetCreateResponse {
+    // Intentionally empty.
+}
+
+message VirtioScsiTargetDeleteRequest {
+    common.v1.ObjectKey target_id = 1;
+}
+
+message VirtioScsiTargetDeleteResponse {
+    uint32 result = 1;
+}
+
+message VirtioScsiTargetUpdateRequest {
+    VirtioScsiTarget target = 1;
+}
+
+message VirtioScsiTargetUpdateResponse {
+    uint32 result = 1;
+}
+
+message VirtioScsiTargetListRequest {
+    // Intentionally empty.
+}
+
+message VirtioScsiTargetListResponse {
+    repeated VirtioScsiTarget target = 1;
+}
+
+message VirtioScsiTargetGetRequest {
+    common.v1.ObjectKey target_id = 1;
+}
+
+message VirtioScsiTargetGetResponse {
+    VirtioScsiTarget target = 1;
+}
+
+message VirtioScsiTargetStatsRequest {
+    common.v1.ObjectKey target_id = 1;
+}
+
+message VirtioScsiTargetStatsResponse {
+    string stats = 1;
 }
 
 message VirtioScsiControllerCreateRequest {
     VirtioScsiController controller = 1;
+
+    // The target to associate this controller with
+    common.v1.ObjectKey target_id = 2;
 }
 
 message VirtioScsiControllerCreateResponse {
@@ -49,7 +118,7 @@ message VirtioScsiControllerCreateResponse {
 }
 
 message VirtioScsiControllerDeleteRequest {
-    int64 controller_id = 1;
+    common.v1.ObjectKey controller_id = 1;
 }
 
 message VirtioScsiControllerDeleteResponse {
@@ -65,7 +134,7 @@ message VirtioScsiControllerUpdateResponse {
 }
 
 message VirtioScsiControllerListRequest {
-    // Intentionally empty.
+    common.v1.ObjectKey target_id = 1;
 }
 
 message VirtioScsiControllerListResponse {
@@ -73,7 +142,7 @@ message VirtioScsiControllerListResponse {
 }
 
 message VirtioScsiControllerGetRequest {
-    int64 controller_id = 1;
+    common.v1.ObjectKey controller_id = 1;
 }
 
 message VirtioScsiControllerGetResponse {
@@ -81,16 +150,22 @@ message VirtioScsiControllerGetResponse {
 }
 
 message VirtioScsiControllerStatsRequest {
-    int64 controller_id = 1;
+    common.v1.ObjectKey id = 1;
 }
 
 message VirtioScsiControllerStatsResponse {
-    int64 id = 1;
+    common.v1.ObjectKey id = 1;
     string stats = 2;
 }
 
 message VirtioScsiLunCreateRequest {
     VirtioScsiLun lun = 1;
+
+    common.v1.ObjectKey target_id = 2;
+
+    // The lun ID inside of the target where this lun
+    // can be found.
+    uint32 lun_id = 3;
 }
 
 message VirtioScsiLunCreateResponse {
@@ -98,8 +173,7 @@ message VirtioScsiLunCreateResponse {
 }
 
 message VirtioScsiLunDeleteRequest {
-    int64 controller_id = 1;
-    int64 lun_id = 2;
+    common.v1.ObjectKey lun_id = 1;
 }
 
 message VirtioScsiLunDeleteResponse {
@@ -115,7 +189,7 @@ message VirtioScsiLunUpdateResponse {
 }
 
 message VirtioScsiLunListRequest {
-    int64 controller_id = 1;
+    common.v1.ObjectKey controller_id = 1;
 }
 
 message VirtioScsiLunListResponse {
@@ -123,8 +197,7 @@ message VirtioScsiLunListResponse {
 }
 
 message VirtioScsiLunGetRequest {
-    int64 controller_id = 1;
-    int64 lun_id = 2;
+    common.v1.ObjectKey lun_id = 1;
 }
 
 message VirtioScsiLunGetResponse {
@@ -132,11 +205,10 @@ message VirtioScsiLunGetResponse {
 }
 
 message VirtioScsiLunStatsRequest {
-    int64 controller_id = 1;
-    int64 lun_id = 2;
+    common.v1.ObjectKey lun_id = 1;
 }
 
 message VirtioScsiLunStatsResponse {
-    int64 id = 1;
+    common.v1.ObjectKey id = 1;
     string stats = 2;
 }


### PR DESCRIPTION
This is a new proposed starting point for a unified set of front-end block APIs can that can work for virtio-blk, NVMe, and NVMe-oF. To be clear right up front, I'm not even certain that I agree with all of these decisions or approve of this set of APIs. But I think it's a good starting point.

What I tried to accomplish here was to unify the front-end APIs but keep the front-end/middle-end/back-end concept in the current OPI model. I've personally been arguing that we need to instead batch these APIs into fewer endpoints for atomicity reasons, but I think at least conceptually the front/middle/back concept is here to stay.

The most important concepts here are as follows:

1) I'm unifying not only exposing an NVMe or virtio-blk device to a host system, but also exposing an NVMe-oF device over the network (so the network is the front end bus).

2) I've introduced a generic "Device" which for NVMe is equivalent to a subsystem.

3) I've introduced the concept of an endpoint. For NVMe/PCIe, this is a controller at some BDF. For other types, it can be re-used and the controller is a more dynamic and short-lived thing.

4) The PCI stuff does not allow the endpoint to specify the BDF. It only lets you pick the PF/VF ids. The BDF is assigned by the OS PCI driver and we cannot pick it in these APIs.

Signed-off-by: Ben Walker <benjamin.walker@intel.com>