### PR TITLE
ci: add apilinter

### DIFF
--- a/inventory/Makefile
+++ b/inventory/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Intel Corporation
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-all: buflint bufgen doc
+all: buflint apilint bufgen doc
 
 doc:
 	rm -rf ./google
@@ -14,6 +14,11 @@ doc:
 
 	docker run --user=$$(id -u):$$(id -g) --rm --entrypoint=sh -v "${PWD}"/v1/:/out -w /out -v "${PWD}":/protos pseudomuto/protoc-gen-doc:1.5.1 -c "protoc -I /protos --doc_out=/out --doc_opt=markdown,autogen.md /protos/*.proto"
 
+	rm -rf "${PWD}"/google
+
+apilint:
+	curl -kL https://github.com/googleapis/googleapis/archive/master.tar.gz | tar --strip=1 -zxvf - googleapis-master/google/api
+	docker run --user=$(id -u):$(id -g) --rm --entrypoint=sh -v "${PWD}":/out -w /out ghcr.io/docker-multiarch/google-api-linter:1.56.1 -c "api-linter /out/*.proto --output-format github --set-exit-status"
 	rm -rf "${PWD}"/google
 
 buflint:

--- a/network/cloud/Makefile
+++ b/network/cloud/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Intel Corporation
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-all: buflint bufgen doc
+all: buflint apilint bufgen doc
 
 doc:
 	rm -rf ./google
@@ -16,6 +16,10 @@ doc:
 
 	rm -rf "${PWD}"/google
 
+apilint:
+	curl -kL https://github.com/googleapis/googleapis/archive/master.tar.gz | tar --strip=1 -zxvf - googleapis-master/google/api
+	docker run --user=$(id -u):$(id -g) --rm --entrypoint=sh -v "${PWD}/../../network/opinetcommon":/common -v "${PWD}":/out -w /out ghcr.io/docker-multiarch/google-api-linter:1.56.1 -c "api-linter -I /common /out/*.proto --output-format github --disable-rule=core::0123 --disable-rule=core::0131 --disable-rule=core::0132 --disable-rule=core::0133 --disable-rule=core::0134 --disable-rule=core::0140 --disable-rule=core::0156 --disable-rule=core::0158 --disable-rule=core::0191 --disable-rule=core::0192 --disable-rule=core::0203 --disable-rule=core::0216 --disable-rule=client-libraries::4232::required-fields --set-exit-status"
+	rm -rf "${PWD}"/google
 
 buflint:
 	docker run --rm -v "${PWD}/../opinetcommon":/opinnetcommon -v "${PWD}":/out -w /out bufbuild/buf lint

--- a/network/evpn-gw/Makefile
+++ b/network/evpn-gw/Makefile
@@ -3,7 +3,7 @@
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 # Copyright (C) 2023 Nordix Foundation.
 
-all: buflint bufgen doc
+all: buflint apilint bufgen doc
 
 doc:
 	rm -rf ./google
@@ -15,6 +15,11 @@ doc:
 
 	docker run --user=$$(id -u):$$(id -g) --rm --entrypoint=sh -v "${PWD}/../opinetcommon":/opinetcommon -v "${PWD}"/v1alpha1/:/out -w /out -v "${PWD}":/protos pseudomuto/protoc-gen-doc:1.5.1 -c "protoc -I /opinetcommon -I /protos --doc_out=/out --doc_opt=markdown,autogen.md /protos/*.proto"
 
+	rm -rf "${PWD}"/google
+
+apilint:
+	curl -kL https://github.com/googleapis/googleapis/archive/master.tar.gz | tar --strip=1 -zxvf - googleapis-master/google/api
+	docker run --user=$(id -u):$(id -g) --rm --entrypoint=sh -v "${PWD}/../../network/opinetcommon":/common -v "${PWD}":/out -w /out ghcr.io/docker-multiarch/google-api-linter:1.56.1 -c "api-linter -I /common /out/*.proto --output-format github --set-exit-status"
 	rm -rf "${PWD}"/google
 
 buflint:

--- a/network/evpn-gw/README.md
+++ b/network/evpn-gw/README.md
@@ -70,23 +70,23 @@ erDiagram
 
 The following objects are managed though the xPU EVPN Gateway API
 
-* **Logical Bridge (LB)**
+* __Logical Bridge (LB)__
 
     Provide L2 forwarding between bridge ports. A logical bridge is a single broadcast domain and corresponds to a single VLAN with its own FDB. The logical bridge gives per VLAN learning.
 
     A Logical Bridge can optionally be associated with an L2-EVPN instance, which extends the L2 forwarding domain beyond the scope of the single server. The VNI value is used as import and export route target in EVPN BGP as well as in the VXLAN encapsulation of the tunneled traffic.
 
-* **Bridge Port (BP)**
+* __Bridge Port (BP)__
 
     A bridge port connects a tenant to one or more Logical Bridges. The model supports both access and trunk ports. An access port receives untagged frames from tenants and maps frames to the configured VLAN of a single logical bridge. Trunk ports forward tagged frames transparently for a set of specified VLANs. Within the xPU the packets are forwarded according to their VLAN tag. A trunk port is hence associated with multiple Logical Bridges.
 
     A typical use case of a bridge port is to configure L2 services for a VF in the host domain. In Kubernetes context a CNI plugin would create the BridgePort and inject the configured VF through a Network Attachment Definition into the Pod
 
-* **Switched Virtual Interface (SVI)**
+* __Switched Virtual Interface (SVI)__
 
     An SVI is a virtual L3 interface that connects a logical Bridge to a VRF on the xPU. The SVI has a MAC address on the Logical Bridge and one or more IP addresses in the VRF , which can act as GW IPs for the tenants connected to the Logical Bridge. The GW IPs must be in the same subnets as the Pod IP addresses assigned through the chosen Kubernetes IPAM plugin.
 
-* **Virtual Routing Funtions (VRF)**
+* __Virtual Routing Funtions (VRF)__
 
     A VRF routes IP packets locally between BridgePorts on LogicalBridges connected through SVIs.
 

--- a/network/k8s/Makefile
+++ b/network/k8s/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Intel Corporation
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-all: buflint bufgen doc
+all: buflint apilint bufgen doc
 
 doc:
 	rm -rf ./google
@@ -16,6 +16,10 @@ doc:
 
 	rm -rf "${PWD}"/google
 
+apilint:
+	curl -kL https://github.com/googleapis/googleapis/archive/master.tar.gz | tar --strip=1 -zxvf - googleapis-master/google/api
+	docker run --user=$(id -u):$(id -g) --rm --entrypoint=sh -v "${PWD}":/out -w /out ghcr.io/docker-multiarch/google-api-linter:1.56.1 -c "api-linter /out/*.proto --output-format github --set-exit-status"
+	rm -rf "${PWD}"/google
 
 buflint:
 	docker run --rm -v "${PWD}/../opinetcommon":/opinnetcommon -v "${PWD}":/out -w /out bufbuild/buf lint

--- a/network/opinetcommon/Makefile
+++ b/network/opinetcommon/Makefile
@@ -2,7 +2,12 @@
 # Copyright (C) 2022 Intel Corporation
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-all: buflint bufgen doc
+all: buflint apilint bufgen doc
+
+apilint:
+	curl -kL https://github.com/googleapis/googleapis/archive/master.tar.gz | tar --strip=1 -zxvf - googleapis-master/google/api
+	docker run --user=$(id -u):$(id -g) --rm --entrypoint=sh -v "${PWD}":/out -w /out ghcr.io/docker-multiarch/google-api-linter:1.56.1 -c "api-linter /out/*.proto --output-format github --set-exit-status"
+	rm -rf "${PWD}"/google
 
 buflint:
 	docker run --rm -v "${PWD}":/out -w /out bufbuild/buf lint

--- a/network/telco/Makefile
+++ b/network/telco/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Intel Corporation
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-all: buflint bufgen doc
+all: buflint apilint bufgen doc
 
 doc:
 	rm -rf ./google
@@ -16,6 +16,10 @@ doc:
 
 	rm -rf "${PWD}"/google
 
+apilint:
+	curl -kL https://github.com/googleapis/googleapis/archive/master.tar.gz | tar --strip=1 -zxvf - googleapis-master/google/api
+	docker run --user=$(id -u):$(id -g) --rm --entrypoint=sh -v "${PWD}":/out -w /out ghcr.io/docker-multiarch/google-api-linter:1.56.1 -c "api-linter /out/*.proto --output-format github --set-exit-status"
+	rm -rf "${PWD}"/google
 
 buflint:
 	docker run --rm -v "${PWD}/../opinetcommon":/opinnetcommon -v "${PWD}":/out -w /out bufbuild/buf lint

--- a/security/Makefile
+++ b/security/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Intel Corporation
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-all: buflint bufgen doc
+all: buflint apilint bufgen doc
 
 doc:
 	rm -rf ./google
@@ -14,6 +14,11 @@ doc:
 
 	docker run --user=$$(id -u):$$(id -g) --rm --entrypoint=sh -v "${PWD}"/v1/:/out -w /out -v "${PWD}":/protos pseudomuto/protoc-gen-doc:1.5.1 -c "protoc -I /protos --doc_out=/out --doc_opt=markdown,autogen.md /protos/*.proto"
 
+	rm -rf "${PWD}"/google
+
+apilint:
+	curl -kL https://github.com/googleapis/googleapis/archive/master.tar.gz | tar --strip=1 -zxvf - googleapis-master/google/api
+	docker run --user=$(id -u):$(id -g) --rm --entrypoint=sh -v "${PWD}":/out -w /out ghcr.io/docker-multiarch/google-api-linter:1.56.1 -c "api-linter -I /common /out/*.proto --output-format github --disable-rule=core::0192 --disable-rule=core::0191 --disable-rule=core::0140 --disable-rule=core::0123 --disable-rule=core::0142 --disable-rule=core::0126 --disable-rule=core::0127 --disable-rule=core::0141 --disable-rule=core::0203 --disable-rule=core::0216 --set-exit-status"
 	rm -rf "${PWD}"/google
 
 buflint:

--- a/storage/Makefile
+++ b/storage/Makefile
@@ -2,7 +2,7 @@
 # Copyright (C) 2022 Intel Corporation
 # Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-all: buflint bufgen doc
+all: buflint apilint bufgen doc
 
 doc:
 	rm -rf ./google
@@ -14,6 +14,11 @@ doc:
 
 	docker run --user=$$(id -u):$$(id -g) --rm --entrypoint=sh -v "${PWD}"/v1alpha1/:/out -w /out -v "${PWD}":/protos pseudomuto/protoc-gen-doc:1.5.1 -c "protoc -I /protos --doc_out=/out --doc_opt=markdown,autogen.md /protos/*.proto"
 
+	rm -rf "${PWD}"/google
+
+apilint:
+	curl -kL https://github.com/googleapis/googleapis/archive/master.tar.gz | tar --strip=1 -zxvf - googleapis-master/google/api
+	docker run --user=$(id -u):$(id -g) --rm --entrypoint=sh -v "${PWD}":/out -w /out ghcr.io/docker-multiarch/google-api-linter:1.56.1 -c "api-linter /out/*.proto --output-format github --set-exit-status"
 	rm -rf "${PWD}"/google
 
 buflint:


### PR DESCRIPTION
Close https://github.com/opiproject/opi-api/issues/444

While there is no google api linter integration with buf, we can run it in our make file separately.

https://github.com/opiproject/opi-api/issues/455

