### PR TITLE
refactor(buf) refactor protobuf files to standard formatting enforced by Buf v2

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -17,5 +17,5 @@ jobs:
           version: 1.50.0
           token: ${{ secrets.BUF_TOKEN}}
           lint: true
-          format: false
+          format: true
           breaking: false

--- a/network/cloud/bgp.proto
+++ b/network/cloud/bgp.proto
@@ -8,20 +8,19 @@
 //        +-> neighbor
 //          +-> [ neighbor config ]
 //          +-> AFI / SAFI [ per-AFI overrides ]";
-// 
+//
 
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "BgpProto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
-import "google/api/field_behavior.proto";
+option java_multiple_files = true;
+option java_outer_classname = "BgpProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // BGP Router object
 message BgpRouter {
@@ -44,7 +43,7 @@ message BgpSpec {
   // the local autonomous system number
   // (-- api-linter: core::0141::forbidden-types=disabled
   //     aip.dev/not-precedent: must use uint32 per BGP spec. --)
-  uint32  local_asn = 1;
+  uint32 local_asn = 1;
   // router ID for this bgp instance
   // (-- api-linter: core::0141::forbidden-types=disabled
   //     aip.dev/not-precedent: must use fixed32 per BGP spec. --)
@@ -99,9 +98,9 @@ message BgpPeerSpec {
   network.opinetcommon.v1alpha1.AdminState state = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
   // BGP local IP address. control plane chooses the local IP address of the
   // session if an all 0 IP address is provided
-  network.opinetcommon.v1alpha1.IPAddress  local_address = 2;
+  network.opinetcommon.v1alpha1.IPAddress local_address = 2;
   // BGP peer IP address
-  network.opinetcommon.v1alpha1.IPAddress  peer_addr = 3;
+  network.opinetcommon.v1alpha1.IPAddress peer_addr = 3;
   // remote 4-byte AS number
   // (-- api-linter: core::0141::forbidden-types=disabled
   //     aip.dev/not-precedent: must use uint32 per BGP spec. --)
@@ -441,8 +440,7 @@ message BGPAdjRibOut {
 
 // BGP Adj-RIB-Out spec for get operations
 // empty for now; add support for more filtered gets in future
-message BGPAdjRibOutSpec {
-}
+message BGPAdjRibOutSpec {}
 
 // BGP Adj-RIB-Out table contains set of routes advertised to all peers
 message BGPAdjRibOutStatus {
@@ -463,12 +461,12 @@ message BGPAdjRibOutStatus {
   // AS path string
   bytes as_path_str = 8;
   // The community list associated with the route after export policy has been applied
-  repeated bytes comm              = 9;
+  repeated bytes comm = 9;
   // The extended community membership associated with the route after export policy has been applied
   repeated bytes ext_comm = 10;
   // BGP Multi-Exit Discriminator value advertised to the peer
   bool med_present = 11;
-  // med value 
+  // med value
   // (-- api-linter: core::0141::forbidden-types=disabled
   //     aip.dev/not-precedent: must use uint32 per BGP spec. --)
   uint32 med = 12;
@@ -479,11 +477,11 @@ enum BGPAfi {
   // AFI_UNSPECIFIED
   BGP_AFI_UNSPECIFIED = 0;
   // AFI_IPV4
-  BGP_AFI_IPV4        = 1;
+  BGP_AFI_IPV4 = 1;
   // AFI_IPv6
-  BGP_AFI_IPV6        = 2;
+  BGP_AFI_IPV6 = 2;
   // AFI_L2VPN
-  BGP_AFI_L2VPN       = 25;
+  BGP_AFI_L2VPN = 25;
 }
 
 // BGP sub-address family identitfier
@@ -491,17 +489,17 @@ enum BGPSafi {
   // SAFI_UNSPECIFIED
   BGP_SAFI_UNSPECIFIED = 0;
   // SAFI_UNICAST
-  BGP_SAFI_UNICAST     = 1;
+  BGP_SAFI_UNICAST = 1;
   // SAFI_EVPN
-  BGP_SAFI_EVPN        = 70;
+  BGP_SAFI_EVPN = 70;
 }
 
 // BGP peer Route Reflector client
 enum BgpPeerRR {
   // RR_UNSPECIFIED
-  BGP_PEER_RR_UNSPECIFIED   = 0;
+  BGP_PEER_RR_UNSPECIFIED = 0;
   // RR_CLIENT
-  BGP_PEER_RR_CLIENT        = 1;
+  BGP_PEER_RR_CLIENT = 1;
   // RR_MESHED_CLIENT
   BGP_PEER_RR_MESHED_CLIENT = 2;
 }
@@ -511,13 +509,13 @@ enum BgpPeerSessionState {
   // unspecified
   BGP_PEER_SESSION_STATE_UNSPECIFIED = 0;
   // idle
-  BGP_PEER_SESSION_STATE_IDLE        = 1;
+  BGP_PEER_SESSION_STATE_IDLE = 1;
   // connect
-  BGP_PEER_SESSION_STATE_CONNECT     = 2;
+  BGP_PEER_SESSION_STATE_CONNECT = 2;
   // active
-  BGP_PEER_SESSION_STATE_ACTIVE      = 3;
+  BGP_PEER_SESSION_STATE_ACTIVE = 3;
   // open-sent
-  BGP_PEER_SESSION_STATE_OPENSENT    = 4;
+  BGP_PEER_SESSION_STATE_OPENSENT = 4;
   // open-confirm
   BGP_PEER_SESSION_STATE_OPENCONFIRM = 5;
   // open-established
@@ -527,11 +525,11 @@ enum BgpPeerSessionState {
 // bgp as size
 enum BgpAsSize {
   // unspecified
-  BGP_AS_SIZE_UNSPECIFIED    = 0;
+  BGP_AS_SIZE_UNSPECIFIED = 0;
   // two bytes
-  BGP_AS_SIZE_TWO_OCTET      = 1;
+  BGP_AS_SIZE_TWO_OCTET = 1;
   // four bytes
-  BGP_AS_SIZE_FOUR_OCTET     = 2;
+  BGP_AS_SIZE_FOUR_OCTET = 2;
 }
 
 // bgp address type
@@ -539,47 +537,47 @@ enum BGPAddrType {
   // other
   BGP_ADDR_TYPE_UNSPECIFIED = 0;
   // ipv4
-  BGP_ADDR_TYPE_IPV4        = 1;
+  BGP_ADDR_TYPE_IPV4 = 1;
   // ipv6
-  BGP_ADDR_TYPE_IPV6        = 2;
+  BGP_ADDR_TYPE_IPV6 = 2;
   // nsap
-  BGP_ADDR_TYPE_NSAP        = 3;
+  BGP_ADDR_TYPE_NSAP = 3;
   // hdlc
-  BGP_ADDR_TYPE_HDLC        = 4;
+  BGP_ADDR_TYPE_HDLC = 4;
   // bbn-1822
-  BGP_ADDR_TYPE_BBN1822     = 5;
+  BGP_ADDR_TYPE_BBN1822 = 5;
   // ieee 802
-  BGP_ADDR_TYPE_IEEE802     = 6;
+  BGP_ADDR_TYPE_IEEE802 = 6;
   // e163
-  BGP_ADDR_TYPE_E163        = 7;
+  BGP_ADDR_TYPE_E163 = 7;
   // e164
-  BGP_ADDR_TYPE_E164        = 8;
+  BGP_ADDR_TYPE_E164 = 8;
   // f69
-  BGP_ADDR_TYPE_F69         = 9;
+  BGP_ADDR_TYPE_F69 = 9;
   // x121
-  BGP_ADDR_TYPE_X121        = 10;
+  BGP_ADDR_TYPE_X121 = 10;
   // ipx
-  BGP_ADDR_TYPE_IPX         = 11;
+  BGP_ADDR_TYPE_IPX = 11;
   // apple-talk
-  BGP_ADDR_TYPE_APPLETALK   = 12;
+  BGP_ADDR_TYPE_APPLETALK = 12;
   // dec net
-  BGP_ADDR_TYPE_DECNETIV    = 13;
+  BGP_ADDR_TYPE_DECNETIV = 13;
   // banyan
-  BGP_ADDR_TYPE_BANYANVIN   = 14;
+  BGP_ADDR_TYPE_BANYANVIN = 14;
   // nsap
-  BGP_ADDR_TYPE_E164_NSAP   = 15;
+  BGP_ADDR_TYPE_E164_NSAP = 15;
   // ipv4 tna
-  BGP_ADDR_TYPE_IPV4_TNA    = 16;
+  BGP_ADDR_TYPE_IPV4_TNA = 16;
   // ipv6 tna
-  BGP_ADDR_TYPE_IPV6_TNA    = 17;
+  BGP_ADDR_TYPE_IPV6_TNA = 17;
   // nsap tna
-  BGP_ADDR_TYPE_NSAP_TNA    = 18;
+  BGP_ADDR_TYPE_NSAP_TNA = 18;
   // vpn ipv4
-  BGP_ADDR_TYPE_VPN_IPV4    = 19;
+  BGP_ADDR_TYPE_VPN_IPV4 = 19;
   // vpn ipv6
-  BGP_ADDR_TYPE_VPN_IPV6    = 20;
+  BGP_ADDR_TYPE_VPN_IPV6 = 20;
   // l2vpn
-  BGP_ADDR_TYPE_L2VPN       = 25;
+  BGP_ADDR_TYPE_L2VPN = 25;
 }
 
 // bgp operational status
@@ -587,15 +585,15 @@ enum BGPOperState {
   // unspecified
   BGP_OPER_STATE_UNSPECIFIED = 0;
   // up
-  BGP_OPER_STATE_UP          = 1;
+  BGP_OPER_STATE_UP = 1;
   // down
-  BGP_OPER_STATE_DOWN        = 2;
+  BGP_OPER_STATE_DOWN = 2;
   // going up
-  BGP_OPER_STATE_GOING_UP    = 3;
+  BGP_OPER_STATE_GOING_UP = 3;
   // going down
-  BGP_OPER_STATE_GOING_DOWN  = 4;
+  BGP_OPER_STATE_GOING_DOWN = 4;
   // activation failed
-  BGP_OPER_STATE_ACT_FAILED  = 5;
+  BGP_OPER_STATE_ACT_FAILED = 5;
 }
 
 // bgp add path capability negotiation
@@ -607,9 +605,9 @@ enum BgpAddPathCapNeg {
   // receive
   BGP_ADD_PATH_CAP_NEG_SR_RECEIVE = 1;
   // send
-  BGP_ADD_PATH_CAP_NEG_SR_SEND    = 2;
+  BGP_ADD_PATH_CAP_NEG_SR_SEND = 2;
   // both
-  BGP_ADD_PATH_CAP_NEG_SR_BOTH    = 3;
+  BGP_ADD_PATH_CAP_NEG_SR_BOTH = 3;
   // inherit
   BGP_ADD_PATH_CAP_NEG_SR_INHERIT = 4;
   // uknown
@@ -619,13 +617,13 @@ enum BgpAddPathCapNeg {
 // clear route request's options
 enum BGPClearRouteOptions {
   // unspecified
-  BGP_CLEAR_ROUTE_OPTIONS_UNSPECIFIED  = 0;
+  BGP_CLEAR_ROUTE_OPTIONS_UNSPECIFIED = 0;
   // toggle session
-  BGP_CLEAR_ROUTE_OPTIONS_HARD         = 1;
+  BGP_CLEAR_ROUTE_OPTIONS_HARD = 1;
   // request route refresh from peer
-  BGP_CLEAR_ROUTE_OPTIONS_REFRESH_IN   = 2;
+  BGP_CLEAR_ROUTE_OPTIONS_REFRESH_IN = 2;
   // send all routes to peer
-  BGP_CLEAR_ROUTE_OPTIONS_REFRESH_OUT  = 3;
+  BGP_CLEAR_ROUTE_OPTIONS_REFRESH_OUT = 3;
   // send all routes to peer and request route refresh from peer
   BGP_CLEAR_ROUTE_OPTIONS_REFRESH_BOTH = 4;
 }
@@ -635,11 +633,11 @@ enum NLRISrc {
   // unspecified
   NLRI_SRC_UNSPECIFIED = 0;
   // learned from peer
-  NLRI_SRC_PEER        = 1;
+  NLRI_SRC_PEER = 1;
   // learned from AFM
-  NLRI_SRC_AFM         = 2;
+  NLRI_SRC_AFM = 2;
   // created by itself
-  NLRI_SRC_SELF        = 3;
+  NLRI_SRC_SELF = 3;
 }
 
 // NLRI active values
@@ -649,9 +647,9 @@ enum BgpNlriIsActive {
   // not tracked
   BGP_NLRI_IS_ACTIVE_NOT_TRACKED = 1;
   // inactive
-  BGP_NLRI_IS_ACTIVE_INACTIVE    = 2;
+  BGP_NLRI_IS_ACTIVE_INACTIVE = 2;
   // active
-  BGP_NLRI_IS_ACTIVE_ACTIVE      = 3;
+  BGP_NLRI_IS_ACTIVE_ACTIVE = 3;
 }
 
 // BGP Reason for not best route
@@ -659,45 +657,45 @@ enum BGPRouteReason {
   // not considered
   // (-- api-linter: core::0126::unspecified=disabled
   //     aip.dev/not-precedent: zero is not-considered, not unspecified. --)
-  BGP_ROUTE_REASON_NOT_CONSIDERED     = 0;
+  BGP_ROUTE_REASON_NOT_CONSIDERED = 0;
   // route is best
-  BGP_ROUTE_REASON_ROUTE_IS_BEST      = 1;
+  BGP_ROUTE_REASON_ROUTE_IS_BEST = 1;
   // weight based
-  BGP_ROUTE_REASON_WEIGHT             = 2;
+  BGP_ROUTE_REASON_WEIGHT = 2;
   // local preference
-  BGP_ROUTE_REASON_LOCAL_PREF         = 3;
+  BGP_ROUTE_REASON_LOCAL_PREF = 3;
   // local origin preferred
-  BGP_ROUTE_REASON_LCL_ORIG_PRFRRED   = 4;
+  BGP_ROUTE_REASON_LCL_ORIG_PRFRRED = 4;
   // as path lengt
-  BGP_ROUTE_REASON_AS_PATH_LEN        = 5;
+  BGP_ROUTE_REASON_AS_PATH_LEN = 5;
   // origin based
-  BGP_ROUTE_REASON_ORIGIN             = 6;
+  BGP_ROUTE_REASON_ORIGIN = 6;
   // med
-  BGP_ROUTE_REASON_MED                = 7;
+  BGP_ROUTE_REASON_MED = 7;
   // origin tie
-  BGP_ROUTE_REASON_LOCAL_ORIG_TIE     = 8;
+  BGP_ROUTE_REASON_LOCAL_ORIG_TIE = 8;
   // ebpg vs. ibgp peer
-  BGP_ROUTE_REASON_EBGP_V_IBGP_PEER   = 9;
+  BGP_ROUTE_REASON_EBGP_V_IBGP_PEER = 9;
   // admin distance
-  BGP_ROUTE_REASON_ADMIN_DISTANCE     = 10;
+  BGP_ROUTE_REASON_ADMIN_DISTANCE = 10;
   // path next to cst
-  BGP_ROUTE_REASON_PATH_TO_NEXT_CST   = 11;
+  BGP_ROUTE_REASON_PATH_TO_NEXT_CST = 11;
   // preferenc existing
-  BGP_ROUTE_REASON_PREF_EXISTING      = 12;
+  BGP_ROUTE_REASON_PREF_EXISTING = 12;
   // reason identifier
   // (-- api-linter: core::0140::abbreviations=disabled
   //     aip.dev/not-precedent: --)
-  BGP_ROUTE_REASON_IDENTIFIER         = 13;
+  BGP_ROUTE_REASON_IDENTIFIER = 13;
   // cluster length
-  BGP_ROUTE_REASON_CLUSTER_LEN        = 14;
+  BGP_ROUTE_REASON_CLUSTER_LEN = 14;
   // peer address type
-  BGP_ROUTE_REASON_PEER_ADDR_TYPE     = 15;
+  BGP_ROUTE_REASON_PEER_ADDR_TYPE = 15;
   // peer address
-  BGP_ROUTE_REASON_PEER_ADDR          = 16;
+  BGP_ROUTE_REASON_PEER_ADDR = 16;
   // peer port
-  BGP_ROUTE_REASON_PEER_PORT          = 17;
+  BGP_ROUTE_REASON_PEER_PORT = 17;
   // path id
-  BGP_ROUTE_REASON_PATH_ID            = 18;
+  BGP_ROUTE_REASON_PATH_ID = 18;
 }
 
 // bgp origin attribute
@@ -705,11 +703,11 @@ enum BGPOriginAttr {
   // unspecified
   BGP_ORIGIN_ATTR_UNSPECIFIED = 0;
   // igp
-  BGP_ORIGIN_ATTR_IGP         = 1;
+  BGP_ORIGIN_ATTR_IGP = 1;
   // egp
-  BGP_ORIGIN_ATTR_EGP         = 2;
+  BGP_ORIGIN_ATTR_EGP = 2;
   // incomplete
-  BGP_ORIGIN_ATTR_INCOMPLETE  = 3;
+  BGP_ORIGIN_ATTR_INCOMPLETE = 3;
 }
 
 // bgp peer type
@@ -717,23 +715,23 @@ enum BgpPeerType {
   // unspecified
   BGP_PEER_TYPE_UNSPECIFIED = 0;
   // none (per protocol)
-  BGP_PEER_TYPE_NONE        = 1;
+  BGP_PEER_TYPE_NONE = 1;
   // ibgp
-  BGP_PEER_TYPE_IBGP        = 2;
+  BGP_PEER_TYPE_IBGP = 2;
   // ebgp
-  BGP_PEER_TYPE_EBGP        = 3;
+  BGP_PEER_TYPE_EBGP = 3;
 }
 
 // BGP ARO Advertisement State
 enum BgpAroAdvertState {
   // unspecified
-  BGP_ARO_ADVERT_STATE_UNSPECIFIED        = 0;
+  BGP_ARO_ADVERT_STATE_UNSPECIFIED = 0;
   // advertised
-  BGP_ARO_ADVERT_STATE_ADVERTISED         = 1;
+  BGP_ARO_ADVERT_STATE_ADVERTISED = 1;
   // suppressed
-  BGP_ARO_ADVERT_STATE_SUPPRESSED         = 2;
+  BGP_ARO_ADVERT_STATE_SUPPRESSED = 2;
   // pending withdrawal
   BGP_ARO_ADVERT_STATE_PENDING_WITHDRAWAL = 3;
   // withdrawn
-  BGP_ARO_ADVERT_STATE_WITHDRAWN          = 4;
+  BGP_ARO_ADVERT_STATE_WITHDRAWN = 4;
 }

--- a/network/cloud/cloudrpc.proto
+++ b/network/cloud/cloudrpc.proto
@@ -4,34 +4,31 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "CloudRPC";
-
-option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
 import "google/api/annotations.proto";
 import "google/api/client.proto";
-import "google/protobuf/empty.proto";
 import "google/api/field_behavior.proto";
-import "google/protobuf/field_mask.proto";
 import "google/api/resource.proto";
-
-import "network/cloud/device.proto";
-import "network/cloud/port.proto";
-import "network/cloud/interface.proto";
-import "network/cloud/route.proto";
-import "network/cloud/vnic.proto";
-import "network/cloud/underlayroute.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
 import "network/cloud/bgp.proto";
-import "network/cloud/nexthop.proto";
+import "network/cloud/device.proto";
+import "network/cloud/interface.proto";
 import "network/cloud/mapping.proto";
+import "network/cloud/networkpolicy.proto";
+import "network/cloud/nexthop.proto";
+import "network/cloud/ospf.proto";
+import "network/cloud/port.proto";
+import "network/cloud/route.proto";
 import "network/cloud/subnet.proto";
 import "network/cloud/tunnel.proto";
+import "network/cloud/underlayroute.proto";
+import "network/cloud/vnic.proto";
 import "network/cloud/vpc.proto";
-import "network/cloud/networkpolicy.proto";
-import "network/cloud/ospf.proto";
 
+option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
+option java_multiple_files = true;
+option java_outer_classname = "CloudRPC";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // Cloud Infra Service configure/operate objects to manage cloud infrastructure
 //  Device Capabilities APIs
@@ -47,828 +44,686 @@ import "network/cloud/ospf.proto";
 //  SecurityProfile APIs
 //
 
-
 // Cloud Infra APIs - to manage a multi-node cloud infrastructure on a xPU
 service CloudInfraService {
-    // device capabilities
-    rpc GetDeviceCapabilities (GetDeviceCapabilitiesRequest) returns (DeviceCapabilities) {
-        option (google.api.http) = {
-            get: "/v1/devicecapabilitiess"
-        };
-        option (google.api.method_signature) = "";
-    }
+  // device capabilities
+  rpc GetDeviceCapabilities(GetDeviceCapabilitiesRequest) returns (DeviceCapabilities) {
+    option (google.api.http) = {get: "/v1/devicecapabilitiess"};
+    option (google.api.method_signature) = "";
+  }
 
-    // device apis
-    rpc CreateDevice (CreateDeviceRequest) returns (Device) {
-        option (google.api.http) = {
-            post: "/v1/devices"
-            body: "device"
-        };
-        option (google.api.method_signature) = "device,device_id";
-    }
-    rpc DeleteDevice (DeleteDeviceRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=devices}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateDevice (UpdateDeviceRequest) returns (Device) {
-        option (google.api.http) = {
-            patch: "/v1/{name=devices}/*"
-            body: "device"
-        };
-        option (google.api.method_signature) = "device, update_mask";
-    }
-    rpc ListDevices (ListDevicesRequest) returns (ListDevicesResponse) {
-        option (google.api.http) = {
-            get: "/v1/devices"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetDevice (GetDeviceRequest) returns (Device) {
-        option (google.api.http) = {
-            get: "/v1/{name=devices}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // device apis
+  rpc CreateDevice(CreateDeviceRequest) returns (Device) {
+    option (google.api.http) = {
+      post: "/v1/devices"
+      body: "device"
+    };
+    option (google.api.method_signature) = "device,device_id";
+  }
+  rpc DeleteDevice(DeleteDeviceRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=devices}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateDevice(UpdateDeviceRequest) returns (Device) {
+    option (google.api.http) = {
+      patch: "/v1/{name=devices}/*"
+      body: "device"
+    };
+    option (google.api.method_signature) = "device, update_mask";
+  }
+  rpc ListDevices(ListDevicesRequest) returns (ListDevicesResponse) {
+    option (google.api.http) = {get: "/v1/devices"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetDevice(GetDeviceRequest) returns (Device) {
+    option (google.api.http) = {get: "/v1/{name=devices}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // port apis
-    rpc UpdatePort (UpdatePortRequest) returns (Port) {
-        option (google.api.http) = {
-            patch: "/v1/{name=ports}/*"
-            body: "port"
-        };
-        option (google.api.method_signature) = "port, update_mask";
-    }
-    rpc ListPorts (ListPortsRequest) returns (ListPortsResponse) {
-        option (google.api.http) = {
-            get: "/v1/ports"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetPort (GetPortRequest) returns (Port) {
-        option (google.api.http) = {
-            get: "/v1/{name=ports}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // port apis
+  rpc UpdatePort(UpdatePortRequest) returns (Port) {
+    option (google.api.http) = {
+      patch: "/v1/{name=ports}/*"
+      body: "port"
+    };
+    option (google.api.method_signature) = "port, update_mask";
+  }
+  rpc ListPorts(ListPortsRequest) returns (ListPortsResponse) {
+    option (google.api.http) = {get: "/v1/ports"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetPort(GetPortRequest) returns (Port) {
+    option (google.api.http) = {get: "/v1/{name=ports}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // vnic apis
-    rpc CreateVnic (CreateVnicRequest) returns (Vnic) {
-        option (google.api.http) = {
-            post: "/v1/vnics"
-            body: "vnic"
-        };
-        option (google.api.method_signature) = "vnic,vnic_id";
-    }
-    rpc DeleteVnic (DeleteVnicRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=vnics}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateVnic (UpdateVnicRequest) returns (Vnic) {
-        option (google.api.http) = {
-            patch: "/v1/{name=vnics}/*"
-            body: "vnic"
-        };
-        option (google.api.method_signature) = "vnic, update_mask";
-    }
-    rpc ListVnics (ListVnicsRequest) returns (ListVnicsResponse) {
-        option (google.api.http) = {
-            get: "/v1/vnics"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetVnic (GetVnicRequest) returns (Vnic) {
-        option (google.api.http) = {
-            get: "/v1/{name=vnics}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // vnic apis
+  rpc CreateVnic(CreateVnicRequest) returns (Vnic) {
+    option (google.api.http) = {
+      post: "/v1/vnics"
+      body: "vnic"
+    };
+    option (google.api.method_signature) = "vnic,vnic_id";
+  }
+  rpc DeleteVnic(DeleteVnicRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=vnics}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateVnic(UpdateVnicRequest) returns (Vnic) {
+    option (google.api.http) = {
+      patch: "/v1/{name=vnics}/*"
+      body: "vnic"
+    };
+    option (google.api.method_signature) = "vnic, update_mask";
+  }
+  rpc ListVnics(ListVnicsRequest) returns (ListVnicsResponse) {
+    option (google.api.http) = {get: "/v1/vnics"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetVnic(GetVnicRequest) returns (Vnic) {
+    option (google.api.http) = {get: "/v1/{name=vnics}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // interface apis
-    rpc CreateInterface (CreateInterfaceRequest) returns (Interface) {
-        option (google.api.http) = {
-            post: "/v1/interfaces"
-            body: "interface"
-        };
-        option (google.api.method_signature) = "interface,interface_id";
-    }
-    rpc DeleteInterface (DeleteInterfaceRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=interfaces}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateInterface (UpdateInterfaceRequest) returns (Interface) {
-        option (google.api.http) = {
-            patch: "/v1/{name=interfaces}/*"
-            body: "interface"
-        };
-        option (google.api.method_signature) = "interface, update_mask";
-    }
-    rpc ListInterfaces (ListInterfacesRequest) returns (ListInterfacesResponse) {
-        option (google.api.http) = {
-            get: "/v1/interfaces"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetInterface (GetInterfaceRequest) returns (Interface) {
-        option (google.api.http) = {
-            get: "/v1/{name=interfaces}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // interface apis
+  rpc CreateInterface(CreateInterfaceRequest) returns (Interface) {
+    option (google.api.http) = {
+      post: "/v1/interfaces"
+      body: "interface"
+    };
+    option (google.api.method_signature) = "interface,interface_id";
+  }
+  rpc DeleteInterface(DeleteInterfaceRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=interfaces}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateInterface(UpdateInterfaceRequest) returns (Interface) {
+    option (google.api.http) = {
+      patch: "/v1/{name=interfaces}/*"
+      body: "interface"
+    };
+    option (google.api.method_signature) = "interface, update_mask";
+  }
+  rpc ListInterfaces(ListInterfacesRequest) returns (ListInterfacesResponse) {
+    option (google.api.http) = {get: "/v1/interfaces"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetInterface(GetInterfaceRequest) returns (Interface) {
+    option (google.api.http) = {get: "/v1/{name=interfaces}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // routetable apis
-    rpc CreateRouteTable (CreateRouteTableRequest) returns (RouteTable) {
-        option (google.api.http) = {
-            post: "/v1/routetables"
-            body: "routetable"
-        };
-        option (google.api.method_signature) = "routetable,routetable_id";
-    }
-    rpc DeleteRouteTable (DeleteRouteTableRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=routetables}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateRouteTable (UpdateRouteTableRequest) returns (RouteTable) {
-        option (google.api.http) = {
-            patch: "/v1/{name=routetables}/*"
-            body: "routetable"
-        };
-        option (google.api.method_signature) = "routetable, update_mask";
-    }
-    rpc ListRouteTables (ListRouteTablesRequest) returns (ListRouteTablesResponse) {
-        option (google.api.http) = {
-            get: "/v1/routetables"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetRouteTable (GetRouteTableRequest) returns (RouteTable) {
-        option (google.api.http) = {
-            get: "/v1/{name=routetables}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // TBD rpc RouteTableGetStreaming (RouteTableGetRequest) returns (stream RouteTableGetResponse) {}
+  // routetable apis
+  rpc CreateRouteTable(CreateRouteTableRequest) returns (RouteTable) {
+    option (google.api.http) = {
+      post: "/v1/routetables"
+      body: "routetable"
+    };
+    option (google.api.method_signature) = "routetable,routetable_id";
+  }
+  rpc DeleteRouteTable(DeleteRouteTableRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=routetables}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateRouteTable(UpdateRouteTableRequest) returns (RouteTable) {
+    option (google.api.http) = {
+      patch: "/v1/{name=routetables}/*"
+      body: "routetable"
+    };
+    option (google.api.method_signature) = "routetable, update_mask";
+  }
+  rpc ListRouteTables(ListRouteTablesRequest) returns (ListRouteTablesResponse) {
+    option (google.api.http) = {get: "/v1/routetables"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetRouteTable(GetRouteTableRequest) returns (RouteTable) {
+    option (google.api.http) = {get: "/v1/{name=routetables}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  // TBD rpc RouteTableGetStreaming (RouteTableGetRequest) returns (stream RouteTableGetResponse) {}
 
+  // route apis
+  rpc CreateRoute(CreateRouteRequest) returns (Route) {
+    option (google.api.http) = {
+      post: "/v1/routes"
+      body: "route"
+    };
+    option (google.api.method_signature) = "route,route_id";
+  }
+  rpc DeleteRoute(DeleteRouteRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=routes}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateRoute(UpdateRouteRequest) returns (Route) {
+    option (google.api.http) = {
+      patch: "/v1/{name=routes}/*"
+      body: "route"
+    };
+    option (google.api.method_signature) = "route, update_mask";
+  }
+  rpc ListRoutes(ListRoutesRequest) returns (ListRoutesResponse) {
+    option (google.api.http) = {get: "/v1/routes"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetRoute(GetRouteRequest) returns (Route) {
+    option (google.api.http) = {get: "/v1/{name=routes}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  // TBD rpc RouteLookup (RouteLookupRequest) returns (RouteLookupResponse) {}
 
-    // route apis
-    rpc CreateRoute (CreateRouteRequest) returns (Route) {
-        option (google.api.http) = {
-            post: "/v1/routes"
-            body: "route"
-        };
-        option (google.api.method_signature) = "route,route_id";
-    }
-    rpc DeleteRoute (DeleteRouteRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=routes}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateRoute (UpdateRouteRequest) returns (Route) {
-        option (google.api.http) = {
-            patch: "/v1/{name=routes}/*"
-            body: "route"
-        };
-        option (google.api.method_signature) = "route, update_mask";
-    }
-    rpc ListRoutes (ListRoutesRequest) returns (ListRoutesResponse) {
-        option (google.api.http) = {
-            get: "/v1/routes"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetRoute (GetRouteRequest) returns (Route) {
-        option (google.api.http) = {
-            get: "/v1/{name=routes}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // TBD rpc RouteLookup (RouteLookupRequest) returns (RouteLookupResponse) {}
+  // underlayroute apis
+  rpc CreateUnderlayRoute(CreateUnderlayRouteRequest) returns (UnderlayRoute) {
+    option (google.api.http) = {
+      post: "/v1/underlayroutes"
+      body: "underlayroute"
+    };
+    option (google.api.method_signature) = "underlayroute,underlayroute_id";
+  }
+  rpc DeleteUnderlayRoute(DeleteUnderlayRouteRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=underlayroutes}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateUnderlayRoute(UpdateUnderlayRouteRequest) returns (UnderlayRoute) {
+    option (google.api.http) = {
+      patch: "/v1/{name=underlayroutes}/*"
+      body: "underlayroute"
+    };
+    option (google.api.method_signature) = "underlayroute, update_mask";
+  }
+  rpc ListUnderlayRoutes(ListUnderlayRoutesRequest) returns (ListUnderlayRoutesResponse) {
+    option (google.api.http) = {get: "/v1/underlayroutes"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetUnderlayRoute(GetUnderlayRouteRequest) returns (UnderlayRoute) {
+    option (google.api.http) = {get: "/v1/{name=underlayroutes}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  // TBD rpc CPRouteLookup (CPRouteGetRequest) returns (CPRouteGetResponse) {}
+  // TBD rpc CPRouteRedistGet (CPRouteRedistGetRequest) returns (CPRouteRedistGetResponse) {}
 
-    // underlayroute apis
-    rpc CreateUnderlayRoute (CreateUnderlayRouteRequest) returns (UnderlayRoute) {
-        option (google.api.http) = {
-            post: "/v1/underlayroutes"
-            body: "underlayroute"
-        };
-        option (google.api.method_signature) = "underlayroute,underlayroute_id";
-    }
-    rpc DeleteUnderlayRoute (DeleteUnderlayRouteRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=underlayroutes}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateUnderlayRoute (UpdateUnderlayRouteRequest) returns (UnderlayRoute) {
-        option (google.api.http) = {
-            patch: "/v1/{name=underlayroutes}/*"
-            body: "underlayroute"
-        };
-        option (google.api.method_signature) = "underlayroute, update_mask";
-    }
-    rpc ListUnderlayRoutes (ListUnderlayRoutesRequest) returns (ListUnderlayRoutesResponse) {
-        option (google.api.http) = {
-            get: "/v1/underlayroutes"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetUnderlayRoute (GetUnderlayRouteRequest) returns (UnderlayRoute) {
-        option (google.api.http) = {
-            get: "/v1/{name=underlayroutes}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // TBD rpc CPRouteLookup (CPRouteGetRequest) returns (CPRouteGetResponse) {}
-    // TBD rpc CPRouteRedistGet (CPRouteRedistGetRequest) returns (CPRouteRedistGetResponse) {}
+  // bgp (optional) apis
+  rpc CreateBgpRouter(CreateBgpRouterRequest) returns (BgpRouter) {
+    option (google.api.http) = {
+      post: "/v1/bgpRouters"
+      body: "bgp_router"
+    };
+    option (google.api.method_signature) = "bgp_router,bgp_router_id";
+  }
+  // BGP Router Delete
+  rpc DeleteBgpRouter(DeleteBgpRouterRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=bgpRouter}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  // BGP Router Update
+  rpc UpdateBgpRouter(UpdateBgpRouterRequest) returns (BgpRouter) {
+    option (google.api.http) = {
+      patch: "/v1/{bgp_router.name=bgpRouters}/*"
+      body: "bgp_router"
+    };
+    option (google.api.method_signature) = "bgp_router,update_mask";
+  }
+  // BGP Router List
+  rpc ListBgpRouters(ListBgpRoutersRequest) returns (ListBgpRoutersResponse) {
+    option (google.api.http) = {get: "/v1/{parent=bgpRouters}"};
+    option (google.api.method_signature) = "parent";
+  }
+  // BGP Router Get
+  rpc GetBgpRouter(GetBgpRouterRequest) returns (BgpRouter) {
+    option (google.api.http) = {get: "/v1/{name=bgpRouters}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // bgp (optional) apis
-    rpc CreateBgpRouter (CreateBgpRouterRequest) returns (BgpRouter) {
-        option (google.api.http) = {
-            post: "/v1/bgpRouters"
-            body: "bgp_router"
-        };
-        option (google.api.method_signature) = "bgp_router,bgp_router_id";
-    }
-    // BGP Router Delete
-    rpc DeleteBgpRouter (DeleteBgpRouterRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=bgpRouter}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // BGP Router Update
-    rpc UpdateBgpRouter (UpdateBgpRouterRequest) returns (BgpRouter) {
-        option (google.api.http) = {
-            patch: "/v1/{bgp_router.name=bgpRouters}/*"
-            body: "bgp_router"
-        };
-        option (google.api.method_signature) = "bgp_router,update_mask";
-    }
-    // BGP Router List
-    rpc ListBgpRouters (ListBgpRoutersRequest) returns (ListBgpRoutersResponse) {
-        option (google.api.http) = {
-            get: "/v1/{parent=bgpRouters}"
-        };
-        option (google.api.method_signature) = "parent";
-    }
-    // BGP Router Get
-    rpc GetBgpRouter (GetBgpRouterRequest) returns (BgpRouter) {
-        option (google.api.http) = {
-            get: "/v1/{name=bgpRouters}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // bgppeer (optional) apis
+  rpc CreateBgpPeer(CreateBgpPeerRequest) returns (BgpPeer) {
+    option (google.api.http) = {
+      post: "/v1/bgpPeers"
+      body: "bgp_peer"
+    };
+    option (google.api.method_signature) = "bgp_peer,bgp_peer_id";
+  }
+  // BGP Peer Delete
+  rpc DeleteBgpPeer(DeleteBgpPeerRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=bgpPeers}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  // BGP Peer Update
+  rpc UpdateBgpPeer(UpdateBgpPeerRequest) returns (BgpPeer) {
+    option (google.api.http) = {
+      patch: "/v1/{bgp_peer.name=bgpPeers}/*"
+      body: "bgp_peer"
+    };
+    option (google.api.method_signature) = "bgp_peer,update_mask";
+  }
+  // BGP Peer List
+  rpc ListBgpPeers(ListBgpPeersRequest) returns (ListBgpPeersResponse) {
+    option (google.api.http) = {get: "/v1/{parent=bgpPeers}"};
+    option (google.api.method_signature) = "parent";
+  }
+  // BGP Peer Get
+  rpc GetBgpPeer(GetBgpPeerRequest) returns (BgpPeer) {
+    option (google.api.http) = {get: "/v1/{name=bgpPeers}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // bgppeer (optional) apis
-    rpc CreateBgpPeer (CreateBgpPeerRequest) returns (BgpPeer) {
-        option (google.api.http) = {
-            post: "/v1/bgpPeers"
-            body: "bgp_peer"
-        };
-        option (google.api.method_signature) = "bgp_peer,bgp_peer_id";
-    }
-    // BGP Peer Delete
-    rpc DeleteBgpPeer (DeleteBgpPeerRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=bgpPeers}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // BGP Peer Update
-    rpc UpdateBgpPeer (UpdateBgpPeerRequest) returns (BgpPeer) {
-        option (google.api.http) = {
-            patch: "/v1/{bgp_peer.name=bgpPeers}/*"
-            body: "bgp_peer"
-        };
-        option (google.api.method_signature) = "bgp_peer,update_mask";
-    }
-    // BGP Peer List
-    rpc ListBgpPeers (ListBgpPeersRequest) returns (ListBgpPeersResponse) {
-        option (google.api.http) = {
-            get: "/v1/{parent=bgpPeers}"
-        };
-        option (google.api.method_signature) = "parent";
-    }
-    // BGP Peer Get
-    rpc GetBgpPeer (GetBgpPeerRequest) returns (BgpPeer) {
-        option (google.api.http) = {
-            get: "/v1/{name=bgpPeers}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // bgppeeraf (optional) apis
+  rpc CreateBgpPeerAf(CreateBgpPeerAfRequest) returns (BgpPeerAf) {
+    option (google.api.http) = {
+      post: "/v1/bgpPeerAfs"
+      body: "bgp_peer_af"
+    };
+    option (google.api.method_signature) = "bgp_peer_af,bgp_peer_af_id";
+  }
+  // BGP Peer AF Delete
+  rpc DeleteBgpPeerAf(DeleteBgpPeerAfRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=bgpPeerAfs}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  // BGP Peer AF Update
+  rpc UpdateBgpPeerAf(UpdateBgpPeerAfRequest) returns (BgpPeerAf) {
+    option (google.api.http) = {
+      patch: "/v1/{bgp_peer_af.name=bgpPeerAfs}/*"
+      body: "bgp_peer_af"
+    };
+    option (google.api.method_signature) = "bgp_peer_af,update_mask";
+  }
+  // BGP Peer AF List
+  rpc ListBgpPeerAfs(ListBgpPeerAfsRequest) returns (ListBgpPeerAfsResponse) {
+    option (google.api.http) = {get: "/v1/{parent=bgpPeerAfs}"};
+    option (google.api.method_signature) = "parent";
+  }
+  // BGP Peer AF Get
+  rpc GetBgpPeerAf(GetBgpPeerAfRequest) returns (BgpPeerAf) {
+    option (google.api.http) = {get: "/v1/{name=bgpPeerAfs}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  // TBD rpc BGPClearRoute (BGPClearRouteRequest) returns (BGPClearRouteResponse) {}
+  // TBD rpc BGPNLRIPrefixGet (BGPNLRIPrefixGetRequest) returns (BGPNLRIPrefixGetResponse) {}
+  // TBD rpc BGPPrfxCntrsGet (BGPPrfxCntrsGetRequest) returns (BGPPrfxCntrsGetResponse) {}
+  // TBD rpc BGPAdjRibOutGet (BGPAdjRibOutGetRequest) returns (BGPAdjRibOutGetResponse) {}
 
-    // bgppeeraf (optional) apis
-    rpc CreateBgpPeerAf (CreateBgpPeerAfRequest) returns (BgpPeerAf) {
-        option (google.api.http) = {
-            post: "/v1/bgpPeerAfs"
-            body: "bgp_peer_af"
-        };
-        option (google.api.method_signature) = "bgp_peer_af,bgp_peer_af_id";
-    }
-    // BGP Peer AF Delete
-    rpc DeleteBgpPeerAf (DeleteBgpPeerAfRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=bgpPeerAfs}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // BGP Peer AF Update
-    rpc UpdateBgpPeerAf (UpdateBgpPeerAfRequest) returns (BgpPeerAf) {
-        option (google.api.http) = {
-            patch: "/v1/{bgp_peer_af.name=bgpPeerAfs}/*"
-            body: "bgp_peer_af"
-        };
-        option (google.api.method_signature) = "bgp_peer_af,update_mask";
-    }
-    // BGP Peer AF List
-    rpc ListBgpPeerAfs (ListBgpPeerAfsRequest) returns (ListBgpPeerAfsResponse) {
-        option (google.api.http) = {
-            get: "/v1/{parent=bgpPeerAfs}"
-        };
-        option (google.api.method_signature) = "parent";
-    }
-    // BGP Peer AF Get
-    rpc GetBgpPeerAf (GetBgpPeerAfRequest) returns (BgpPeerAf) {
-        option (google.api.http) = {
-            get: "/v1/{name=bgpPeerAfs}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // TBD rpc BGPClearRoute (BGPClearRouteRequest) returns (BGPClearRouteResponse) {}
-    // TBD rpc BGPNLRIPrefixGet (BGPNLRIPrefixGetRequest) returns (BGPNLRIPrefixGetResponse) {}
-    // TBD rpc BGPPrfxCntrsGet (BGPPrfxCntrsGetRequest) returns (BGPPrfxCntrsGetResponse) {}
-    // TBD rpc BGPAdjRibOutGet (BGPAdjRibOutGetRequest) returns (BGPAdjRibOutGetResponse) {}
+  // mapping apis
+  rpc CreateMapping(CreateMappingRequest) returns (Mapping) {
+    option (google.api.http) = {
+      post: "/v1/mappings"
+      body: "mapping"
+    };
+    option (google.api.method_signature) = "mapping,mapping_id";
+  }
+  rpc DeleteMapping(DeleteMappingRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=mappings}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateMapping(UpdateMappingRequest) returns (Mapping) {
+    option (google.api.http) = {
+      patch: "/v1/{name=mappings}/*"
+      body: "mapping"
+    };
+    option (google.api.method_signature) = "mapping, update_mask";
+  }
+  rpc ListMappings(ListMappingsRequest) returns (ListMappingsResponse) {
+    option (google.api.http) = {get: "/v1/mappings"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetMapping(GetMappingRequest) returns (Mapping) {
+    option (google.api.http) = {get: "/v1/{name=mappings}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  // TBD rpc MappingGetStreaming (MappingGetRequest) returns (stream MappingGetResponse) {}
 
-    // mapping apis
-    rpc CreateMapping (CreateMappingRequest) returns (Mapping) {
-        option (google.api.http) = {
-            post: "/v1/mappings"
-            body: "mapping"
-        };
-        option (google.api.method_signature) = "mapping,mapping_id";
-    }
-    rpc DeleteMapping (DeleteMappingRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=mappings}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateMapping (UpdateMappingRequest) returns (Mapping) {
-        option (google.api.http) = {
-            patch: "/v1/{name=mappings}/*"
-            body: "mapping"
-        };
-        option (google.api.method_signature) = "mapping, update_mask";
-    }
-    rpc ListMappings (ListMappingsRequest) returns (ListMappingsResponse) {
-        option (google.api.http) = {
-            get: "/v1/mappings"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetMapping (GetMappingRequest) returns (Mapping) {
-        option (google.api.http) = {
-            get: "/v1/{name=mappings}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // TBD rpc MappingGetStreaming (MappingGetRequest) returns (stream MappingGetResponse) {}
+  // nexthop apis
+  rpc CreateNextHop(CreateNextHopRequest) returns (NextHop) {
+    option (google.api.http) = {
+      post: "/v1/nexthops"
+      body: "nexthop"
+    };
+    option (google.api.method_signature) = "nexthop,nexthop_id";
+  }
+  rpc DeleteNextHop(DeleteNextHopRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=nexthops}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateNextHop(UpdateNextHopRequest) returns (NextHop) {
+    option (google.api.http) = {
+      patch: "/v1/{name=nexthops}/*"
+      body: "nexthop"
+    };
+    option (google.api.method_signature) = "nexthop, update_mask";
+  }
+  rpc ListNextHop(ListNextHopRequest) returns (ListNextHopsResponse) {
+    option (google.api.http) = {get: "/v1/nexthops"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetNextHop(GetNextHopRequest) returns (NextHop) {
+    option (google.api.http) = {get: "/v1/{name=nexthops}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // nexthop apis
-    rpc CreateNextHop (CreateNextHopRequest) returns (NextHop) {
-        option (google.api.http) = {
-            post: "/v1/nexthops"
-            body: "nexthop"
-        };
-        option (google.api.method_signature) = "nexthop,nexthop_id";
-    }
-    rpc DeleteNextHop (DeleteNextHopRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=nexthops}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateNextHop (UpdateNextHopRequest) returns (NextHop) {
-        option (google.api.http) = {
-            patch: "/v1/{name=nexthops}/*"
-            body: "nexthop"
-        };
-        option (google.api.method_signature) = "nexthop, update_mask";
-    }
-    rpc ListNextHop (ListNextHopRequest) returns (ListNextHopsResponse) {
-        option (google.api.http) = {
-            get: "/v1/nexthops"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetNextHop (GetNextHopRequest) returns (NextHop) {
-        option (google.api.http) = {
-            get: "/v1/{name=nexthops}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // nexthopgroup apis
+  rpc CreateNextHopGroup(CreateNextHopGroupRequest) returns (NextHopGroup) {
+    option (google.api.http) = {
+      post: "/v1/nexthopgroups"
+      body: "nexthopgroup"
+    };
+    option (google.api.method_signature) = "nexthopgroup,nexthopgroup_id";
+  }
+  rpc DeleteNextHopGroup(DeleteNextHopGroupRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=nexthopgroups}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateNextHopGroup(UpdateNextHopGroupRequest) returns (NextHopGroup) {
+    option (google.api.http) = {
+      patch: "/v1/{name=nexthopgroups}/*"
+      body: "nexthopgroup"
+    };
+    option (google.api.method_signature) = "nexthopgroup, update_mask";
+  }
+  rpc ListNextHopGroups(ListNextHopGroupsRequest) returns (ListNextHopGroupsResponse) {
+    option (google.api.http) = {get: "/v1/nexthopgroups"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetNextHopGroup(GetNextHopGroupRequest) returns (NextHopGroup) {
+    option (google.api.http) = {get: "/v1/{name=nexthopgroups}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // nexthopgroup apis
-    rpc CreateNextHopGroup (CreateNextHopGroupRequest) returns (NextHopGroup) {
-        option (google.api.http) = {
-            post: "/v1/nexthopgroups"
-            body: "nexthopgroup"
-        };
-        option (google.api.method_signature) = "nexthopgroup,nexthopgroup_id";
-    }
-    rpc DeleteNextHopGroup (DeleteNextHopGroupRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=nexthopgroups}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateNextHopGroup (UpdateNextHopGroupRequest) returns (NextHopGroup) {
-        option (google.api.http) = {
-            patch: "/v1/{name=nexthopgroups}/*"
-            body: "nexthopgroup"
-        };
-        option (google.api.method_signature) = "nexthopgroup, update_mask";
-    }
-    rpc ListNextHopGroups (ListNextHopGroupsRequest) returns (ListNextHopGroupsResponse) {
-        option (google.api.http) = {
-            get: "/v1/nexthopgroups"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetNextHopGroup (GetNextHopGroupRequest) returns (NextHopGroup) {
-        option (google.api.http) = {
-            get: "/v1/{name=nexthopgroups}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // subnet apis
+  rpc CreateSubnet(CreateSubnetRequest) returns (Subnet) {
+    option (google.api.http) = {
+      post: "/v1/subnets"
+      body: "subnet"
+    };
+    option (google.api.method_signature) = "subnet,subnet_id";
+  }
+  rpc DeleteSubnet(DeleteSubnetRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=subnets}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateSubnet(UpdateSubnetRequest) returns (Subnet) {
+    option (google.api.http) = {
+      patch: "/v1/{name=subnets}/*"
+      body: "subnet"
+    };
+    option (google.api.method_signature) = "subnet, update_mask";
+  }
+  rpc ListSubnets(ListSubnetsRequest) returns (ListSubnetsResponse) {
+    option (google.api.http) = {get: "/v1/subnets"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetSubnet(GetSubnetRequest) returns (Subnet) {
+    option (google.api.http) = {get: "/v1/{name=subnets}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // subnet apis
-    rpc CreateSubnet (CreateSubnetRequest) returns (Subnet) {
-        option (google.api.http) = {
-            post: "/v1/subnets"
-            body: "subnet"
-        };
-        option (google.api.method_signature) = "subnet,subnet_id";
-    }
-    rpc DeleteSubnet (DeleteSubnetRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=subnets}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateSubnet (UpdateSubnetRequest) returns (Subnet) {
-        option (google.api.http) = {
-            patch: "/v1/{name=subnets}/*"
-            body: "subnet"
-        };
-        option (google.api.method_signature) = "subnet, update_mask";
-    }
-    rpc ListSubnets (ListSubnetsRequest) returns (ListSubnetsResponse) {
-        option (google.api.http) = {
-            get: "/v1/subnets"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetSubnet (GetSubnetRequest) returns (Subnet) {
-        option (google.api.http) = {
-            get: "/v1/{name=subnets}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // tunnel apis
+  rpc CreateTunnel(CreateTunnelRequest) returns (Tunnel) {
+    option (google.api.http) = {
+      post: "/v1/tunnels"
+      body: "tunnel"
+    };
+    option (google.api.method_signature) = "tunnel,tunnel_id";
+  }
+  rpc DeleteTunnel(DeleteTunnelRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=tunnels}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateTunnel(UpdateTunnelRequest) returns (Tunnel) {
+    option (google.api.http) = {
+      patch: "/v1/{name=tunnels}/*"
+      body: "tunnel"
+    };
+    option (google.api.method_signature) = "tunnel, update_mask";
+  }
+  rpc ListTunnels(ListTunnelsRequest) returns (ListTunnelsResponse) {
+    option (google.api.http) = {get: "/v1/tunnels"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetTunnel(GetTunnelRequest) returns (Tunnel) {
+    option (google.api.http) = {get: "/v1/{name=tunnels}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // tunnel apis
-    rpc CreateTunnel (CreateTunnelRequest) returns (Tunnel) {
-        option (google.api.http) = {
-            post: "/v1/tunnels"
-            body: "tunnel"
-        };
-        option (google.api.method_signature) = "tunnel,tunnel_id";
-    }
-    rpc DeleteTunnel (DeleteTunnelRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=tunnels}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateTunnel (UpdateTunnelRequest) returns (Tunnel) {
-        option (google.api.http) = {
-            patch: "/v1/{name=tunnels}/*"
-            body: "tunnel"
-        };
-        option (google.api.method_signature) = "tunnel, update_mask";
-    }
-    rpc ListTunnels (ListTunnelsRequest) returns (ListTunnelsResponse) {
-        option (google.api.http) = {
-            get: "/v1/tunnels"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetTunnel (GetTunnelRequest) returns (Tunnel) {
-        option (google.api.http) = {
-            get: "/v1/{name=tunnels}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // vpc apis
+  rpc CreateVpc(CreateVpcRequest) returns (Vpc) {
+    option (google.api.http) = {
+      post: "/v1/vpcs"
+      body: "vpc"
+    };
+    option (google.api.method_signature) = "vpc,vpc_id";
+  }
+  rpc DeleteVpc(DeleteVpcRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=vpcs}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateVpc(UpdateVpcRequest) returns (Vpc) {
+    option (google.api.http) = {
+      patch: "/v1/{name=vpcs}/*"
+      body: "vpc"
+    };
+    option (google.api.method_signature) = "vpc, update_mask";
+  }
+  rpc ListVpcs(ListVpcsRequest) returns (ListVpcsResponse) {
+    option (google.api.http) = {get: "/v1/vpcs"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetVpc(GetVpcRequest) returns (Vpc) {
+    option (google.api.http) = {get: "/v1/{name=vpcs}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // vpc apis
-    rpc CreateVpc (CreateVpcRequest) returns (Vpc) {
-        option (google.api.http) = {
-            post: "/v1/vpcs"
-            body: "vpc"
-        };
-        option (google.api.method_signature) = "vpc,vpc_id";
-    }
-    rpc DeleteVpc (DeleteVpcRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=vpcs}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateVpc (UpdateVpcRequest) returns (Vpc) {
-        option (google.api.http) = {
-            patch: "/v1/{name=vpcs}/*"
-            body: "vpc"
-        };
-        option (google.api.method_signature) = "vpc, update_mask";
-    }
-    rpc ListVpcs (ListVpcsRequest) returns (ListVpcsResponse) {
-        option (google.api.http) = {
-            get: "/v1/vpcs"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetVpc (GetVpcRequest) returns (Vpc) {
-        option (google.api.http) = {
-            get: "/v1/{name=vpcs}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // vpcpeer apis
+  rpc CreateVPCPeer(CreateVPCPeerRequest) returns (VPCPeer) {
+    option (google.api.http) = {
+      post: "/v1/vpcpeers"
+      body: "vpcpeer"
+    };
+    option (google.api.method_signature) = "vpcpeer,vpcpeer_id";
+  }
+  rpc DeleteVPCPeer(DeleteVPCPeerRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=vpcpeers}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateVPCPeer(UpdateVPCPeerRequest) returns (VPCPeer) {
+    option (google.api.http) = {
+      patch: "/v1/{name=vpcpeers}/*"
+      body: "vpcpeer"
+    };
+    option (google.api.method_signature) = "vpcpeer, update_mask";
+  }
+  rpc ListVPCPeers(ListVPCPeersRequest) returns (ListVPCPeersResponse) {
+    option (google.api.http) = {get: "/v1/vpcpeers"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetVPCPeer(GetVPCPeerRequest) returns (VPCPeer) {
+    option (google.api.http) = {get: "/v1/{name=vpcpeers}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // vpcpeer apis
-    rpc CreateVPCPeer (CreateVPCPeerRequest) returns (VPCPeer) {
-        option (google.api.http) = {
-            post: "/v1/vpcpeers"
-            body: "vpcpeer"
-        };
-        option (google.api.method_signature) = "vpcpeer,vpcpeer_id";
-    }
-    rpc DeleteVPCPeer (DeleteVPCPeerRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=vpcpeers}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateVPCPeer (UpdateVPCPeerRequest) returns (VPCPeer) {
-        option (google.api.http) = {
-            patch: "/v1/{name=vpcpeers}/*"
-            body: "vpcpeer"
-        };
-        option (google.api.method_signature) = "vpcpeer, update_mask";
-    }
-    rpc ListVPCPeers (ListVPCPeersRequest) returns (ListVPCPeersResponse) {
-        option (google.api.http) = {
-            get: "/v1/vpcpeers"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetVPCPeer (GetVPCPeerRequest) returns (VPCPeer) {
-        option (google.api.http) = {
-            get: "/v1/{name=vpcpeers}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // securitypolicy apis
+  rpc CreateSecurityPolicy(CreateSecurityPolicyRequest) returns (SecurityPolicy) {
+    option (google.api.http) = {
+      post: "/v1/securitypolicys"
+      body: "securitypolicy"
+    };
+    option (google.api.method_signature) = "securitypolicy,securitypolicy_id";
+  }
+  rpc DeleteSecurityPolicy(DeleteSecurityPolicyRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=securitypolicys}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateSecurityPolicy(UpdateSecurityPolicyRequest) returns (SecurityPolicy) {
+    option (google.api.http) = {
+      patch: "/v1/{name=securitypolicys}/*"
+      body: "securitypolicy"
+    };
+    option (google.api.method_signature) = "securitypolicy, update_mask";
+  }
+  rpc ListSecurityPolicys(ListSecurityPolicysRequest) returns (ListSecurityPolicysResponse) {
+    option (google.api.http) = {get: "/v1/securitypolicys"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetSecurityPolicy(GetSecurityPolicyRequest) returns (SecurityPolicy) {
+    option (google.api.http) = {get: "/v1/{name=securitypolicys}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // securitypolicy apis
-    rpc CreateSecurityPolicy (CreateSecurityPolicyRequest) returns (SecurityPolicy) {
-        option (google.api.http) = {
-            post: "/v1/securitypolicys"
-            body: "securitypolicy"
-        };
-        option (google.api.method_signature) = "securitypolicy,securitypolicy_id";
-    }
-    rpc DeleteSecurityPolicy (DeleteSecurityPolicyRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=securitypolicys}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateSecurityPolicy (UpdateSecurityPolicyRequest) returns (SecurityPolicy) {
-        option (google.api.http) = {
-            patch: "/v1/{name=securitypolicys}/*"
-            body: "securitypolicy"
-        };
-        option (google.api.method_signature) = "securitypolicy, update_mask";
-    }
-    rpc ListSecurityPolicys (ListSecurityPolicysRequest) returns (ListSecurityPolicysResponse) {
-        option (google.api.http) = {
-            get: "/v1/securitypolicys"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetSecurityPolicy (GetSecurityPolicyRequest) returns (SecurityPolicy) {
-        option (google.api.http) = {
-            get: "/v1/{name=securitypolicys}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // securityrule apis
+  rpc CreateSecurityRule(CreateSecurityRuleRequest) returns (SecurityRule) {
+    option (google.api.http) = {
+      post: "/v1/securityrules"
+      body: "securityrule"
+    };
+    option (google.api.method_signature) = "securityrule,securityrule_id";
+  }
+  rpc DeleteSecurityRule(DeleteSecurityRuleRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=securityrules}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateSecurityRule(UpdateSecurityRuleRequest) returns (SecurityRule) {
+    option (google.api.http) = {
+      patch: "/v1/{name=securityrules}/*"
+      body: "securityrule"
+    };
+    option (google.api.method_signature) = "securityrule, update_mask";
+  }
+  rpc ListSecurityRules(ListSecurityRulesRequest) returns (ListSecurityRulesResponse) {
+    option (google.api.http) = {get: "/v1/securityrules"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetSecurityRule(GetSecurityRuleRequest) returns (SecurityRule) {
+    option (google.api.http) = {get: "/v1/{name=securityrules}/*"};
+    option (google.api.method_signature) = "name";
+  }
 
-    // securityrule apis
-    rpc CreateSecurityRule (CreateSecurityRuleRequest) returns (SecurityRule) {
-        option (google.api.http) = {
-            post: "/v1/securityrules"
-            body: "securityrule"
-        };
-        option (google.api.method_signature) = "securityrule,securityrule_id";
-    }
-    rpc DeleteSecurityRule (DeleteSecurityRuleRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=securityrules}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateSecurityRule (UpdateSecurityRuleRequest) returns (SecurityRule) {
-        option (google.api.http) = {
-            patch: "/v1/{name=securityrules}/*"
-            body: "securityrule"
-        };
-        option (google.api.method_signature) = "securityrule, update_mask";
-    }
-    rpc ListSecurityRules (ListSecurityRulesRequest) returns (ListSecurityRulesResponse) {
-        option (google.api.http) = {
-            get: "/v1/securityrules"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetSecurityRule (GetSecurityRuleRequest) returns (SecurityRule) {
-        option (google.api.http) = {
-            get: "/v1/{name=securityrules}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
+  // securityprofile apis
+  rpc CreateSecurityProfile(CreateSecurityProfileRequest) returns (SecurityProfile) {
+    option (google.api.http) = {
+      post: "/v1/securityprofiles"
+      body: "securityprofile"
+    };
+    option (google.api.method_signature) = "securityprofile,securityprofile_id";
+  }
+  rpc DeleteSecurityProfile(DeleteSecurityProfileRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=securityprofiles}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  rpc UpdateSecurityProfile(UpdateSecurityProfileRequest) returns (SecurityProfile) {
+    option (google.api.http) = {
+      patch: "/v1/{name=securityprofiles}/*"
+      body: "securityprofile"
+    };
+    option (google.api.method_signature) = "securityprofile, update_mask";
+  }
+  rpc ListSecurityProfiles(ListSecurityProfilesRequest) returns (ListSecurityProfilesResponse) {
+    option (google.api.http) = {get: "/v1/securityprofiles"};
+    option (google.api.method_signature) = "";
+  }
+  rpc GetSecurityProfile(GetSecurityProfileRequest) returns (SecurityProfile) {
+    option (google.api.http) = {get: "/v1/{name=securityprofiles}/*"};
+    option (google.api.method_signature) = "name";
+  }
+  //  TBD rpc SecurityPolicyGetStreaming (SecurityPolicyGetRequest) returns (stream SecurityPolicyGetResponse) {}
+  //  TBD rpc SecurityPolicyLookup (SecurityPolicyLookupRequest) returns (SecurityPolicyLookupResponse) {}
 
-    // securityprofile apis
-    rpc CreateSecurityProfile (CreateSecurityProfileRequest) returns (SecurityProfile) {
-        option (google.api.http) = {
-            post: "/v1/securityprofiles"
-            body: "securityprofile"
-        };
-        option (google.api.method_signature) = "securityprofile,securityprofile_id";
-    }
-    rpc DeleteSecurityProfile (DeleteSecurityProfileRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1/{name=securityprofiles}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    rpc UpdateSecurityProfile (UpdateSecurityProfileRequest) returns (SecurityProfile) {
-        option (google.api.http) = {
-            patch: "/v1/{name=securityprofiles}/*"
-            body: "securityprofile"
-        };
-        option (google.api.method_signature) = "securityprofile, update_mask";
-    }
-    rpc ListSecurityProfiles (ListSecurityProfilesRequest) returns (ListSecurityProfilesResponse) {
-        option (google.api.http) = {
-            get: "/v1/securityprofiles"
-        };
-        option (google.api.method_signature) = "";
-    }
-    rpc GetSecurityProfile (GetSecurityProfileRequest) returns (SecurityProfile) {
-        option (google.api.http) = {
-            get: "/v1/{name=securityprofiles}/*"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    //  TBD rpc SecurityPolicyGetStreaming (SecurityPolicyGetRequest) returns (stream SecurityPolicyGetResponse) {}
-    //  TBD rpc SecurityPolicyLookup (SecurityPolicyLookupRequest) returns (SecurityPolicyLookupResponse) {}
+  // OSPF APIs
+  // Create a OSPF Router. Contains the configuration of the OSPF instance.
+  rpc CreateOspfRouter(CreateOspfRouterRequest) returns (OspfRouter) {
+    option (google.api.http) = {
+      post: "/v1alpha1/ospfRouters"
+      body: "ospf_router"
+    };
+    option (google.api.method_signature) = "ospf_router,ospf_router_id";
+  }
+  // Update a OSPF Router instance
+  rpc UpdateOspfRouter(UpdateOspfRouterRequest) returns (OspfRouter) {
+    option (google.api.http) = {
+      patch: "/v1alpha1/{ospf_router.name=ospfRouters/*}"
+      body: "ospf_router"
+    };
+    option (google.api.method_signature) = "ospf_router,update_mask";
+  }
+  // Delete a OSPF instance
+  rpc DeleteOspfRouter(DeleteOspfRouterRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1alpha1/{name=ospfRouters/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Get an OSPF instance
+  rpc GetOspfRouter(GetOspfRouterRequest) returns (OspfRouter) {
+    option (google.api.http) = {get: "/v1alpha1/{name=ospfRouters/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // All OSPF instances
+  rpc ListOspfRouters(ListOspfRoutersRequest) returns (ListOspfRoutersResponse) {
+    option (google.api.http) = {get: "/v1alpha1/ospfRouters"};
+  }
 
-    // OSPF APIs
-    // Create a OSPF Router. Contains the configuration of the OSPF instance.
-    rpc CreateOspfRouter(CreateOspfRouterRequest) returns (OspfRouter) {
-        option (google.api.http) = {
-            post: "/v1alpha1/ospfRouters"
-            body: "ospf_router"
-        };
-        option (google.api.method_signature) = "ospf_router,ospf_router_id";
-    }
-    // Update a OSPF Router instance
-    rpc UpdateOspfRouter(UpdateOspfRouterRequest) returns (OspfRouter) {
-        option (google.api.http) = {
-            patch: "/v1alpha1/{ospf_router.name=ospfRouters/*}"
-            body: "ospf_router"
-        };
-        option (google.api.method_signature) = "ospf_router,update_mask";
-    }
-    // Delete a OSPF instance
-    rpc DeleteOspfRouter(DeleteOspfRouterRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1alpha1/{name=ospfRouters/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Get an OSPF instance
-    rpc GetOspfRouter(GetOspfRouterRequest) returns (OspfRouter) {
-        option (google.api.http) = {
-            get: "/v1alpha1/{name=ospfRouters/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // All OSPF instances
-    rpc ListOspfRouters(ListOspfRoutersRequest) returns (ListOspfRoutersResponse) {
-        option (google.api.http) = {
-            get: "/v1alpha1/ospfRouters"
-        };
-    }
+  // Create a OSPF Area
+  rpc CreateOspfArea(CreateOspfAreaRequest) returns (OspfArea) {
+    option (google.api.http) = {
+      post: "/v1alpha1/ospfAreas"
+      body: "ospf_area"
+    };
+    option (google.api.method_signature) = "ospf_area,ospf_area_id";
+  }
+  // Update an OSPF Area
+  rpc UpdateOspfArea(UpdateOspfAreaRequest) returns (OspfArea) {
+    option (google.api.http) = {
+      patch: "/v1alpha1/{ospf_area.name=ospfAreas/*}"
+      body: "ospf_area"
+    };
+    option (google.api.method_signature) = "ospf_area,update_mask";
+  }
+  // Delete an OSPF Area
+  rpc DeleteOspfArea(DeleteOspfAreaRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1alpha1/{name=ospfAreas/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Get an OSPF Area
+  rpc GetOspfArea(GetOspfAreaRequest) returns (OspfArea) {
+    option (google.api.http) = {get: "/v1alpha1/{name=ospfAreas/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // List all OSPF Areas
+  rpc ListOspfAreas(ListOspfAreasRequest) returns (ListOspfAreasResponse) {
+    option (google.api.http) = {get: "/v1alpha1/ospfAreas"};
+  }
 
-    // Create a OSPF Area
-    rpc CreateOspfArea(CreateOspfAreaRequest) returns (OspfArea) {
-        option (google.api.http) = {
-            post: "/v1alpha1/ospfAreas"
-            body: "ospf_area"
-        };
-        option (google.api.method_signature) = "ospf_area,ospf_area_id";
-    }
-    // Update an OSPF Area
-    rpc UpdateOspfArea(UpdateOspfAreaRequest) returns (OspfArea) {
-        option (google.api.http) = {
-            patch: "/v1alpha1/{ospf_area.name=ospfAreas/*}"
-            body: "ospf_area"
-        };
-        option (google.api.method_signature) = "ospf_area,update_mask";
-    }
-    // Delete an OSPF Area
-    rpc DeleteOspfArea(DeleteOspfAreaRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1alpha1/{name=ospfAreas/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Get an OSPF Area
-    rpc GetOspfArea(GetOspfAreaRequest) returns (OspfArea) {
-        option (google.api.http) = {
-            get: "/v1alpha1/{name=ospfAreas/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // List all OSPF Areas
-    rpc ListOspfAreas(ListOspfAreasRequest) returns (ListOspfAreasResponse) {
-        option (google.api.http) = {
-            get: "/v1alpha1/ospfAreas"
-        };
-    }
-
-    // Create an OSPF IfNetwork
-    rpc CreateOspfIfNetwork(CreateOspfIfNetworkRequest) returns (OspfIfNetwork) {
-        option (google.api.http) = {
-            post: "/v1alpha1/ospfIfNetworks"
-            body: "ospf_if_network"
-        };
-        option (google.api.method_signature) = "ospf_if_network,ospf_if_network_id";
-    }
-    // Update an OSPF IfNetwork
-    rpc UpdateOspfIfNetwork(UpdateOspfIfNetworkRequest) returns (OspfIfNetwork) {
-        option (google.api.http) = {
-            patch: "/v1alpha1/{ospf_if_network.name=ospfIfNetworks/*}"
-            body: "ospf_if_network"
-        };
-        option (google.api.method_signature) = "ospf_if_network,update_mask";
-    }
-    // Delete an OSPF IfNetwork
-    rpc DeleteOspfIfNetwork(DeleteOspfIfNetworkRequest) returns (google.protobuf.Empty) {
-        option (google.api.http) = {
-            delete: "/v1alpha1/{name=ospfIfNetwork/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Get an OSPF IfNetwork
-    rpc GetOspfIfNetwork(GetOspfIfNetworkRequest) returns (OspfIfNetwork) {
-        option (google.api.http) = {
-            get: "/v1alpha1/{name=ospfIfNetworks/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // List all OSPF IfNetworks
-    rpc ListOspfIfNetworks(ListOspfIfNetworksRequest) returns (ListOspfIfNetworksResponse) {
-        option (google.api.http) = {
-            get: "/v1alpha1/ospfIfNetworks"
-        };
-    }
+  // Create an OSPF IfNetwork
+  rpc CreateOspfIfNetwork(CreateOspfIfNetworkRequest) returns (OspfIfNetwork) {
+    option (google.api.http) = {
+      post: "/v1alpha1/ospfIfNetworks"
+      body: "ospf_if_network"
+    };
+    option (google.api.method_signature) = "ospf_if_network,ospf_if_network_id";
+  }
+  // Update an OSPF IfNetwork
+  rpc UpdateOspfIfNetwork(UpdateOspfIfNetworkRequest) returns (OspfIfNetwork) {
+    option (google.api.http) = {
+      patch: "/v1alpha1/{ospf_if_network.name=ospfIfNetworks/*}"
+      body: "ospf_if_network"
+    };
+    option (google.api.method_signature) = "ospf_if_network,update_mask";
+  }
+  // Delete an OSPF IfNetwork
+  rpc DeleteOspfIfNetwork(DeleteOspfIfNetworkRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1alpha1/{name=ospfIfNetwork/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Get an OSPF IfNetwork
+  rpc GetOspfIfNetwork(GetOspfIfNetworkRequest) returns (OspfIfNetwork) {
+    option (google.api.http) = {get: "/v1alpha1/{name=ospfIfNetworks/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // List all OSPF IfNetworks
+  rpc ListOspfIfNetworks(ListOspfIfNetworksRequest) returns (ListOspfIfNetworksResponse) {
+    option (google.api.http) = {get: "/v1alpha1/ospfIfNetworks"};
+  }
 }
 
 //
 // Device Capabilities Requests/Responses
 
-
 // Get DeviceCapabilities Request
-message GetDeviceCapabilitiesRequest {
-}
+message GetDeviceCapabilitiesRequest {}
 
 //
 // Device Requests/Responses
@@ -876,111 +731,111 @@ message GetDeviceCapabilitiesRequest {
 
 // Create Device Request
 message CreateDeviceRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
-    ];
-    // device
-    Device device = 2 [(google.api.field_behavior) = REQUIRED];
-    // device_id
-    string device_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
+  ];
+  // device
+  Device device = 2 [(google.api.field_behavior) = REQUIRED];
+  // device_id
+  string device_id = 3;
 }
 
 // Delete device request
 message DeleteDeviceRequest {
-    // device id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // device id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update device request
 message UpdateDeviceRequest {
-    // Name of device updated
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
-    ];
-    // updated device info
-    Device device = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of device updated
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
+  ];
+  // updated device info
+  Device device = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List device request
 message ListDevicesRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List device response
 message ListDevicesResponse {
-    // list of devices
-    repeated Device device = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of devices
+  repeated Device device = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get device request
 message GetDeviceRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Device"
+  ];
 }
 
 // Update port request
 message UpdatePortRequest {
-    // Name of port requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Port"
-    ];
-    // updated port info
-    Port port = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of port requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Port"
+  ];
+  // updated port info
+  Port port = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List port request
 message ListPortsRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Port"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Port"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List port response
 message ListPortsResponse {
-    // list of ports
-    repeated Port port = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of ports
+  repeated Port port = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get port request
 message GetPortRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Port"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Port"
+  ];
 }
 
 //
@@ -989,69 +844,69 @@ message GetPortRequest {
 
 // Create Vnic Request
 message CreateVnicRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
-    ];
-    // vnic
-    Vnic vnic = 2 [(google.api.field_behavior) = REQUIRED];
-    // vnic_id
-    string vnic_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
+  ];
+  // vnic
+  Vnic vnic = 2 [(google.api.field_behavior) = REQUIRED];
+  // vnic_id
+  string vnic_id = 3;
 }
 
 // Delete vnic request
 message DeleteVnicRequest {
-    // vnic id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // vnic id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update vnic request
 message UpdateVnicRequest {
-    // Name of Vnic requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
-    ];
-    // updated vnic info
-    Vnic vnic = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of Vnic requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
+  ];
+  // updated vnic info
+  Vnic vnic = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List vnic request
 message ListVnicsRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List vnic response
 message ListVnicsResponse {
-    // list of vnics
-    repeated Vnic vnic = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of vnics
+  repeated Vnic vnic = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get vnic request
 message GetVnicRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vnic"
+  ];
 }
 //
 // Interface Requests/Responses
@@ -1059,69 +914,69 @@ message GetVnicRequest {
 
 // Create Interface Request
 message CreateInterfaceRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
-    ];
-    // interface
-    Interface interface = 2 [(google.api.field_behavior) = REQUIRED];
-    // interface_id
-    string interface_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
+  ];
+  // interface
+  Interface interface = 2 [(google.api.field_behavior) = REQUIRED];
+  // interface_id
+  string interface_id = 3;
 }
 
 // Delete interface request
 message DeleteInterfaceRequest {
-    // interface id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // interface id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update interface request
 message UpdateInterfaceRequest {
-    // Name of interface requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
-    ];
-    // updated interface info
-    Interface interface = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of interface requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
+  ];
+  // updated interface info
+  Interface interface = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List interface request
 message ListInterfacesRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List interface response
 message ListInterfacesResponse {
-    // list of interfaces
-    repeated Interface interface = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of interfaces
+  repeated Interface interface = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get interface request
 message GetInterfaceRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Interface"
+  ];
 }
 
 //
@@ -1130,69 +985,69 @@ message GetInterfaceRequest {
 
 // Create RouteTable Request
 message CreateRouteTableRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
-    ];
-    // routetable
-    RouteTable routetable = 2 [(google.api.field_behavior) = REQUIRED];
-    // routetable_id
-    string routetable_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
+  ];
+  // routetable
+  RouteTable routetable = 2 [(google.api.field_behavior) = REQUIRED];
+  // routetable_id
+  string routetable_id = 3;
 }
 
 // Delete routetable request
 message DeleteRouteTableRequest {
-    // routetable id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // routetable id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update routetable request
 message UpdateRouteTableRequest {
-    // Name of route table requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
-    ];
-    // updated routetable info
-    RouteTable routetable = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of route table requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
+  ];
+  // updated routetable info
+  RouteTable routetable = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List routetable request
 message ListRouteTablesRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List routetable response
 message ListRouteTablesResponse {
-    // list of routetables
-    repeated RouteTable routetable = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of routetables
+  repeated RouteTable routetable = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get routetable request
 message GetRouteTableRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/RouteTable"
+  ];
 }
 
 //
@@ -1201,69 +1056,69 @@ message GetRouteTableRequest {
 
 // Create Route Request
 message CreateRouteRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
-    ];
-    // route
-    Route route = 2 [(google.api.field_behavior) = REQUIRED];
-    // route_id
-    string route_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
+  ];
+  // route
+  Route route = 2 [(google.api.field_behavior) = REQUIRED];
+  // route_id
+  string route_id = 3;
 }
 
 // Delete route request
 message DeleteRouteRequest {
-    // route id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // route id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update route request
 message UpdateRouteRequest {
-    // Name of route requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
-    ];
-    // updated route info
-    Route route = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of route requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
+  ];
+  // updated route info
+  Route route = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List route request
 message ListRoutesRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List route response
 message ListRoutesResponse {
-    // list of routes
-    repeated Route route = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of routes
+  repeated Route route = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get route request
 message GetRouteRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Route"
+  ];
 }
 
 //
@@ -1272,69 +1127,69 @@ message GetRouteRequest {
 
 // Create UnderlayRoute Request
 message CreateUnderlayRouteRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
-    ];
-    // underlayroute
-    UnderlayRoute underlayroute = 2 [(google.api.field_behavior) = REQUIRED];
-    // underlayroute_id
-    string underlayroute_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
+  ];
+  // underlayroute
+  UnderlayRoute underlayroute = 2 [(google.api.field_behavior) = REQUIRED];
+  // underlayroute_id
+  string underlayroute_id = 3;
 }
 
 // Delete underlayroute request
 message DeleteUnderlayRouteRequest {
-    // underlayroute id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // underlayroute id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update underlayroute request
 message UpdateUnderlayRouteRequest {
-    // Name of underlay route requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
-    ];
-    // updated underlayroute info
-    UnderlayRoute underlayroute = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of underlay route requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
+  ];
+  // updated underlayroute info
+  UnderlayRoute underlayroute = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List underlayroute request
 message ListUnderlayRoutesRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List underlayroute response
 message ListUnderlayRoutesResponse {
-    // list of underlayroutes
-    repeated UnderlayRoute underlayroute = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of underlayroutes
+  repeated UnderlayRoute underlayroute = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get underlayroute request
 message GetUnderlayRouteRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/UnderlayRoute"
+  ];
 }
 
 //
@@ -1342,59 +1197,59 @@ message GetUnderlayRouteRequest {
 //
 // Create BgpRouter Request
 message CreateBgpRouterRequest {
-    // bgp
-    BgpRouter bgp_router = 1 [(google.api.field_behavior) = REQUIRED];
-    // bgp_id
-    string bgp_router_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // bgp
+  BgpRouter bgp_router = 1 [(google.api.field_behavior) = REQUIRED];
+  // bgp_id
+  string bgp_router_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Delete BgpRouter request
 message DeleteBgpRouterRequest {
-    // bgp id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpRouter"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
+  // bgp id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpRouter"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Update BgpRouter request
 message UpdateBgpRouterRequest {
-    // updated bgp router info
-    BgpRouter bgp_router = 1 [(google.api.field_behavior) = REQUIRED];
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // updated bgp router info
+  BgpRouter bgp_router = 1 [(google.api.field_behavior) = REQUIRED];
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // List BgpRouter request
 message ListBgpRoutersRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpRouter"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpRouter"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List BgpRouter response
 message ListBgpRoutersResponse {
-    // list of bgp routers
-    repeated BgpRouter bgp = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of bgp routers
+  repeated BgpRouter bgp = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get bgp request
 message GetBgpRouterRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpRouter"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpRouter"
+  ];
 }
 
 //
@@ -1402,59 +1257,59 @@ message GetBgpRouterRequest {
 //
 // Create BgpPeer Request
 message CreateBgpPeerRequest {
-    // bgp_peer_id
-    string bgp_peer_id = 1 [(google.api.field_behavior) = REQUIRED];
-    // bgp_peer
-    BgpPeer bgp_peer = 2 [(google.api.field_behavior) = REQUIRED];
+  // bgp_peer_id
+  string bgp_peer_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // bgp_peer
+  BgpPeer bgp_peer = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Delete BGP Peer request
 message DeleteBgpPeerRequest {
-    // bgp peer id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeer"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // bgp peer id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeer"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update bgp peer request
 message UpdateBgpPeerRequest {
-    // updated bgp peer info
-    BgpPeer bgp_peer = 1 [(google.api.field_behavior) = REQUIRED];
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // updated bgp peer info
+  BgpPeer bgp_peer = 1 [(google.api.field_behavior) = REQUIRED];
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // List bgp peer request
 message ListBgpPeersRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeer"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeer"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List bgp peer response
 message ListBgpPeersResponse {
-    // list of bgp peers
-    repeated BgpPeer bgp_peer = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of bgp peers
+  repeated BgpPeer bgp_peer = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get bgp peer request
 message GetBgpPeerRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeer"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeer"
+  ];
 }
 
 //
@@ -1462,59 +1317,59 @@ message GetBgpPeerRequest {
 //
 // Create BgpPeerAf Request
 message CreateBgpPeerAfRequest {
-    // bgp_peer_af
-    BgpPeerAf bgp_peer_af = 1 [(google.api.field_behavior) = REQUIRED];
-    // bgp_peer_af_id
-    string bgp_peer_af_id = 2 [(google.api.field_behavior) = REQUIRED];
+  // bgp_peer_af
+  BgpPeerAf bgp_peer_af = 1 [(google.api.field_behavior) = REQUIRED];
+  // bgp_peer_af_id
+  string bgp_peer_af_id = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Delete bgp peer af request
 message DeleteBgpPeerAfRequest {
-    // bgp peer af id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeerAf"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // bgp peer af id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeerAf"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update bgp peer af request
 message UpdateBgpPeerAfRequest {
-    // updated bgp peer af info
-    BgpPeerAf bgp_peer_af = 1 [(google.api.field_behavior) = REQUIRED];
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // updated bgp peer af info
+  BgpPeerAf bgp_peer_af = 1 [(google.api.field_behavior) = REQUIRED];
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // List bgp peer af request
 message ListBgpPeerAfsRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeerAf"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeerAf"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List bgp peer af response
 message ListBgpPeerAfsResponse {
-    // list of bgp peer afs
-    repeated BgpPeerAf bgp_peer_af = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of bgp peer afs
+  repeated BgpPeerAf bgp_peer_af = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get bgp peer af request
 message GetBgpPeerAfRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeerAf"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/BgpPeerAf"
+  ];
 }
 
 //
@@ -1523,69 +1378,69 @@ message GetBgpPeerAfRequest {
 
 // Create Mapping Request
 message CreateMappingRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
-    ];
-    // mapping
-    Mapping mapping = 2 [(google.api.field_behavior) = REQUIRED];
-    // mapping_id
-    string mapping_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
+  ];
+  // mapping
+  Mapping mapping = 2 [(google.api.field_behavior) = REQUIRED];
+  // mapping_id
+  string mapping_id = 3;
 }
 
 // Delete mapping request
 message DeleteMappingRequest {
-    // mapping id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // mapping id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update mapping request
 message UpdateMappingRequest {
-    // Name of mapping requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
-    ];
-    // updated mapping info
-    Mapping mapping = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of mapping requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
+  ];
+  // updated mapping info
+  Mapping mapping = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List mapping request
 message ListMappingsRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List mapping response
 message ListMappingsResponse {
-    // list of mappings
-    repeated Mapping mapping = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of mappings
+  repeated Mapping mapping = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get mapping request
 message GetMappingRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Mapping"
+  ];
 }
 
 //
@@ -1594,69 +1449,69 @@ message GetMappingRequest {
 
 // Create NextHop Request
 message CreateNextHopRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
-    ];
-    // nexthop
-    NextHop nexthop = 2 [(google.api.field_behavior) = REQUIRED];
-    // nexthop_id
-    string nexthop_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
+  ];
+  // nexthop
+  NextHop nexthop = 2 [(google.api.field_behavior) = REQUIRED];
+  // nexthop_id
+  string nexthop_id = 3;
 }
 
 // Delete nexthop request
 message DeleteNextHopRequest {
-    // nexthop id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // nexthop id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update nexthop request
 message UpdateNextHopRequest {
-    // Name of nexthop requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
-    ];
-    // updated nexthop info
-    NextHop nexthop = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of nexthop requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
+  ];
+  // updated nexthop info
+  NextHop nexthop = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List nexthop request
 message ListNextHopRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List nexthop response
 message ListNextHopsResponse {
-    // list of nexthops
-    repeated NextHop nexthop = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of nexthops
+  repeated NextHop nexthop = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get nexthop request
 message GetNextHopRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHop"
+  ];
 }
 
 //
@@ -1665,69 +1520,69 @@ message GetNextHopRequest {
 
 // Create NextHopGroup Request
 message CreateNextHopGroupRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
-    ];
-    // nexthopgroup
-    NextHopGroup nexthopgroup = 2 [(google.api.field_behavior) = REQUIRED];
-    // nexthopgroup_id
-    string nexthopgroup_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
+  ];
+  // nexthopgroup
+  NextHopGroup nexthopgroup = 2 [(google.api.field_behavior) = REQUIRED];
+  // nexthopgroup_id
+  string nexthopgroup_id = 3;
 }
 
 // Delete nexthopgroup request
 message DeleteNextHopGroupRequest {
-    // nexthopgroup id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // nexthopgroup id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update nexthopgroup request
 message UpdateNextHopGroupRequest {
-    // Name of next hop group requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
-    ];
-    // updated nexthopgroup info
-    NextHopGroup nexthopgroup = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of next hop group requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
+  ];
+  // updated nexthopgroup info
+  NextHopGroup nexthopgroup = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List nexthopgroup request
 message ListNextHopGroupsRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List nexthopgroup response
 message ListNextHopGroupsResponse {
-    // list of nexthopgroups
-    repeated NextHopGroup nexthopgroup = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of nexthopgroups
+  repeated NextHopGroup nexthopgroup = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get nexthopgroup request
 message GetNextHopGroupRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/NextHopGroup"
+  ];
 }
 
 //
@@ -1736,68 +1591,68 @@ message GetNextHopGroupRequest {
 
 // Create Subnet Request
 message CreateSubnetRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
-    ];
-    // subnet
-    Subnet subnet = 2 [(google.api.field_behavior) = REQUIRED];
-    // subnet_id
-    string subnet_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
+  ];
+  // subnet
+  Subnet subnet = 2 [(google.api.field_behavior) = REQUIRED];
+  // subnet_id
+  string subnet_id = 3;
 }
 
 // Delete subnet request
 message DeleteSubnetRequest {
-    // subnet id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // subnet id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update subnet request
 message UpdateSubnetRequest {
-    // Name of subnet requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
-    ];    // updated subnet info
-    Subnet subnet = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of subnet requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
+  ]; // updated subnet info
+  Subnet subnet = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List subnet request
 message ListSubnetsRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List subnet response
 message ListSubnetsResponse {
-    // list of subnets
-    repeated Subnet subnet = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of subnets
+  repeated Subnet subnet = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get subnet request
 message GetSubnetRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Subnet"
+  ];
 }
 
 //
@@ -1806,69 +1661,69 @@ message GetSubnetRequest {
 
 // Create Tunnel Request
 message CreateTunnelRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
-    ];
-    // tunnel
-    Tunnel tunnel = 2 [(google.api.field_behavior) = REQUIRED];
-    // tunnel_id
-    string tunnel_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
+  ];
+  // tunnel
+  Tunnel tunnel = 2 [(google.api.field_behavior) = REQUIRED];
+  // tunnel_id
+  string tunnel_id = 3;
 }
 
 // Delete Tunnel request
 message DeleteTunnelRequest {
-    // tunnel id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // tunnel id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update Tunnel request
 message UpdateTunnelRequest {
-    // Name of tunnel requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
-    ];
-    // updated tunnel info
-    Tunnel tunnel = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of tunnel requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
+  ];
+  // updated tunnel info
+  Tunnel tunnel = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List Tunnel request
 message ListTunnelsRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List Tunnel response
 message ListTunnelsResponse {
-    // list of tunnels
-    repeated Tunnel tunnel = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of tunnels
+  repeated Tunnel tunnel = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get Tunnel request
 message GetTunnelRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Tunnel"
+  ];
 }
 
 //
@@ -1877,69 +1732,69 @@ message GetTunnelRequest {
 
 // Create Vpc Request
 message CreateVpcRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
-    ];
-    // vpc
-    Vpc vpc = 2 [(google.api.field_behavior) = REQUIRED];
-    // vpc_id
-    string vpc_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
+  ];
+  // vpc
+  Vpc vpc = 2 [(google.api.field_behavior) = REQUIRED];
+  // vpc_id
+  string vpc_id = 3;
 }
 
 // Delete vpc request
 message DeleteVpcRequest {
-    // vpc id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // vpc id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update vpc request
 message UpdateVpcRequest {
-    // Name of vpc requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
-    ];
-    // updated vpc info
-    Vpc vpc = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of vpc requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
+  ];
+  // updated vpc info
+  Vpc vpc = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List vpc request
 message ListVpcsRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List vpc response
 message ListVpcsResponse {
-    // list of vpcs
-    repeated Vpc vpc = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of vpcs
+  repeated Vpc vpc = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get vpc request
 message GetVpcRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/Vpc"
+  ];
 }
 
 //
@@ -1948,69 +1803,69 @@ message GetVpcRequest {
 
 // Create VPCPeer Request
 message CreateVPCPeerRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
-    ];
-    // vpcpeer
-    VPCPeer vpcpeer = 2 [(google.api.field_behavior) = REQUIRED];
-    // vpcpeer_id
-    string vpcpeer_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
+  ];
+  // vpcpeer
+  VPCPeer vpcpeer = 2 [(google.api.field_behavior) = REQUIRED];
+  // vpcpeer_id
+  string vpcpeer_id = 3;
 }
 
 // Delete vpcpeer request
 message DeleteVPCPeerRequest {
-    // vpcpeer id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // vpcpeer id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update vpcpeer request
 message UpdateVPCPeerRequest {
-    // Name of vpc peer requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
-    ];
-    // updated vpcpeer info
-    VPCPeer vpcpeer = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of vpc peer requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
+  ];
+  // updated vpcpeer info
+  VPCPeer vpcpeer = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List vpcpeer request
 message ListVPCPeersRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List vpcpeer response
 message ListVPCPeersResponse {
-    // list of vpcpeers
-    repeated VPCPeer vpcpeer = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of vpcpeers
+  repeated VPCPeer vpcpeer = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get vpcpeer request
 message GetVPCPeerRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/VPCPeer"
+  ];
 }
 
 //
@@ -2019,69 +1874,69 @@ message GetVPCPeerRequest {
 
 // Create SecurityPolicy Request
 message CreateSecurityPolicyRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
-    ];
-    // securitypolicy
-    SecurityPolicy securitypolicy = 2 [(google.api.field_behavior) = REQUIRED];
-    // securitypolicy_id
-    string securitypolicy_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
+  ];
+  // securitypolicy
+  SecurityPolicy securitypolicy = 2 [(google.api.field_behavior) = REQUIRED];
+  // securitypolicy_id
+  string securitypolicy_id = 3;
 }
 
 // Delete securitypolicy request
 message DeleteSecurityPolicyRequest {
-    // securitypolicy id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // securitypolicy id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update securitypolicy request
 message UpdateSecurityPolicyRequest {
-    // Name of security policy requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
-    ];
-    // updated securitypolicy info
-    SecurityPolicy securitypolicy = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of security policy requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
+  ];
+  // updated securitypolicy info
+  SecurityPolicy securitypolicy = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List securitypolicy request
 message ListSecurityPolicysRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List securitypolicy response
 message ListSecurityPolicysResponse {
-    // list of securitypolicys
-    repeated SecurityPolicy securitypolicy = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of securitypolicys
+  repeated SecurityPolicy securitypolicy = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get securitypolicy request
 message GetSecurityPolicyRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityPolicy"
+  ];
 }
 
 //
@@ -2090,69 +1945,69 @@ message GetSecurityPolicyRequest {
 
 // Create SecurityRule Request
 message CreateSecurityRuleRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
-    ];
-    // securityrule
-    SecurityRule securityrule = 2 [(google.api.field_behavior) = REQUIRED];
-    // securityrule_id
-    string securityrule_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
+  ];
+  // securityrule
+  SecurityRule securityrule = 2 [(google.api.field_behavior) = REQUIRED];
+  // securityrule_id
+  string securityrule_id = 3;
 }
 
 // Delete securityrule request
 message DeleteSecurityRuleRequest {
-    // securityrule id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // securityrule id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update securityrule request
 message UpdateSecurityRuleRequest {
-    // Name of security rule requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
-    ];
-    // updated securityrule info
-    SecurityRule securityrule = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of security rule requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
+  ];
+  // updated securityrule info
+  SecurityRule securityrule = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List securityrule request
 message ListSecurityRulesRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List securityrule response
 message ListSecurityRulesResponse {
-    // list of securityrules
-    repeated SecurityRule securityrule = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of securityrules
+  repeated SecurityRule securityrule = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get securityrule request
 message GetSecurityRuleRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityRule"
+  ];
 }
 
 //
@@ -2161,69 +2016,69 @@ message GetSecurityRuleRequest {
 
 // Create SecurityProfile Request
 message CreateSecurityProfileRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
-    ];
-    // securityprofile
-    SecurityProfile securityprofile = 2 [(google.api.field_behavior) = REQUIRED];
-    // securityprofile_id
-    string securityprofile_id = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
+  ];
+  // securityprofile
+  SecurityProfile securityprofile = 2 [(google.api.field_behavior) = REQUIRED];
+  // securityprofile_id
+  string securityprofile_id = 3;
 }
 
 // Delete securityprofile request
 message DeleteSecurityProfileRequest {
-    // securityprofile id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2;
+  // securityprofile id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2;
 }
 
 // Update securityprofile request
 message UpdateSecurityProfileRequest {
-    // Name of security profile requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
-    ];
-    // updated securityprofile info
-    SecurityProfile securityprofile = 2;
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 3;
+  // Name of security profile requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
+  ];
+  // updated securityprofile info
+  SecurityProfile securityprofile = 2;
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 3;
 }
 
 // List securityprofile request
 message ListSecurityProfilesRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
-    ];
-    // pagination: page-size
-    int32 page_size = 2;
-    // pagination: start token
-    string page_token = 3;
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
+  ];
+  // pagination: page-size
+  int32 page_size = 2;
+  // pagination: start token
+  string page_token = 3;
 }
 
 // List securityprofile response
 message ListSecurityProfilesResponse {
-    // list of securityprofiles
-    repeated SecurityProfile securityprofile = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of securityprofiles
+  repeated SecurityProfile securityprofile = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Get securityprofile request
 message GetSecurityProfileRequest {
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
-    ];
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/SecurityProfile"
+  ];
 }
 
 //
@@ -2232,63 +2087,63 @@ message GetSecurityProfileRequest {
 
 // Create OSPF Router Request
 message CreateOspfRouterRequest {
-    // OSPF identifier
-    string ospf_router_id = 1 [(google.api.field_behavior) = OPTIONAL];
-    // OSPF configuration
-    OspfRouter ospf_router = 2 [(google.api.field_behavior) = REQUIRED];
+  // OSPF identifier
+  string ospf_router_id = 1 [(google.api.field_behavior) = OPTIONAL];
+  // OSPF configuration
+  OspfRouter ospf_router = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Update OSPF request
 message UpdateOspfRouterRequest {
-    // updated ospf configuration
-    OspfRouter ospf_router = 1 [(google.api.field_behavior) = REQUIRED];
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // updated ospf configuration
+  OspfRouter ospf_router = 1 [(google.api.field_behavior) = REQUIRED];
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Delete OSPF request
 message DeleteOspfRouterRequest {
-    // Name or OSPF identifier
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "OspfRouter"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Name or OSPF identifier
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "OspfRouter"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Get OSPF request
 message GetOspfRouterRequest {
-    // Name of the OSPF Config to retrieve
-    string name = 1 [
-        (google.api.field_behavior) = OPTIONAL,
-        (google.api.resource_reference).type = "OspfRouter"
-    ];
+  // Name of the OSPF Config to retrieve
+  string name = 1 [
+    (google.api.field_behavior) = OPTIONAL,
+    (google.api.resource_reference).type = "OspfRouter"
+  ];
 }
 
 // List OSPF request
 message ListOspfRoutersRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/OspfRouter"
-    ];
-    // The maximum number of OSPF routers to return. The service may return fewer than this value.
-    int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
-    // A page token, received from a previous `ListOspfRouters` call.
-    // Provide this to retrieve the subsequent page.
-    string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/OspfRouter"
+  ];
+  // The maximum number of OSPF routers to return. The service may return fewer than this value.
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // A page token, received from a previous `ListOspfRouters` call.
+  // Provide this to retrieve the subsequent page.
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // List OSPF response
 message ListOspfRoutersResponse {
-    // List of OSPF configs
-    repeated OspfRouter ospf_routers = 1;
+  // List of OSPF configs
+  repeated OspfRouter ospf_routers = 1;
 
-    // A token that can be sent as `page_token` to retrieve the next page.
-    // If this field is omitted, there are not subsequent pages.
-    string next_page_token = 2;
+  // A token that can be sent as `page_token` to retrieve the next page.
+  // If this field is omitted, there are not subsequent pages.
+  string next_page_token = 2;
 }
 
 //
@@ -2297,61 +2152,61 @@ message ListOspfRoutersResponse {
 
 // Create OspfArea Request
 message CreateOspfAreaRequest {
-    // ospf_area_id
-    string ospf_area_id = 1 [(google.api.field_behavior) = REQUIRED];
-    // ospf_area
-    OspfArea ospf_area = 2 [(google.api.field_behavior) = REQUIRED];
+  // ospf_area_id
+  string ospf_area_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // ospf_area
+  OspfArea ospf_area = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Update OspfArea request
 message UpdateOspfAreaRequest {
-    // updated ospf_area info
-    OspfArea ospf_area = 1 [(google.api.field_behavior) = REQUIRED];
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // updated ospf_area info
+  OspfArea ospf_area = 1 [(google.api.field_behavior) = REQUIRED];
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Delete OspfArea request
 message DeleteOspfAreaRequest {
-    // name or area_id
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "OspfArea"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
+  // name or area_id
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "OspfArea"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Get OspfArea request
 message GetOspfAreaRequest {
-    // name
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "OspfArea"
-    ];
+  // name
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "OspfArea"
+  ];
 }
 
 // List OspfArea request
 message ListOspfAreasRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/OspfRouter"
-    ];
-    // pagination: page-size
-    int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
-    // pagination: start token
-    string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/OspfRouter"
+  ];
+  // pagination: page-size
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // pagination: start token
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // List OspfArea response
 message ListOspfAreasResponse {
-    // list of ospf_areas
-    repeated OspfArea ospf_areas = 1;
+  // list of ospf_areas
+  repeated OspfArea ospf_areas = 1;
 
-    // next page token
-    string next_page_token = 2;
+  // next page token
+  string next_page_token = 2;
 }
 
 //
@@ -2360,61 +2215,61 @@ message ListOspfAreasResponse {
 
 // Create OspfIfNetwork Request
 message CreateOspfIfNetworkRequest {
-    // OSPF IfNetwork ID
-    string ospf_if_network_id = 1 [(google.api.field_behavior) = REQUIRED];
-    // ospf_if_network
-    OspfIfNetwork ospf_if_network = 2 [(google.api.field_behavior) = REQUIRED];
+  // OSPF IfNetwork ID
+  string ospf_if_network_id = 1 [(google.api.field_behavior) = REQUIRED];
+  // ospf_if_network
+  OspfIfNetwork ospf_if_network = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // Update OspfIfNetwork request
 message UpdateOspfIfNetworkRequest {
-    // updated OSPF IfNetwork information
-    OspfIfNetwork ospf_if_network = 1 [(google.api.field_behavior) = REQUIRED];
-    // list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
-    // If set to true, and the object is not found, a new object will be created.
-    // In this situation, `update_mask` is ignored.
-    bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
+  // updated OSPF IfNetwork information
+  OspfIfNetwork ospf_if_network = 1 [(google.api.field_behavior) = REQUIRED];
+  // list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // If set to true, and the object is not found, a new object will be created.
+  // In this situation, `update_mask` is ignored.
+  bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Delete OspfIfNetwork request
 message DeleteOspfIfNetworkRequest {
-    // OSPF IfNetwork name
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "OspfIfNetwork"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
+  // OSPF IfNetwork name
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "OspfIfNetwork"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Get OspfIfNetwork request
 message GetOspfIfNetworkRequest {
-    // name
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1alpha1/OspfIfNetwork"
-    ];
+  // name
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1alpha1/OspfIfNetwork"
+  ];
 }
 
 // List OspfIfNetwork request
 message ListOspfIfNetworksRequest {
-    // parent or IfNetwork identifier
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "OspfIfNetwork"
-    ];
-    // pagination: page-size
-    int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
-    // pagination: start token
-    string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+  // parent or IfNetwork identifier
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "OspfIfNetwork"
+  ];
+  // pagination: page-size
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // pagination: start token
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // List OspfIfNetwork response
 message ListOspfIfNetworksResponse {
-    // list of OspfIfNetwork
-    repeated OspfIfNetwork ospf_if_networks = 1;
-    // next page token
-    string next_page_token = 2;
+  // list of OspfIfNetwork
+  repeated OspfIfNetwork ospf_if_networks = 1;
+  // next page token
+  string next_page_token = 2;
 }

--- a/network/cloud/device.proto
+++ b/network/cloud/device.proto
@@ -4,16 +4,14 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "DeviceProto";
-
-option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
 import "network/opinetcommon/networktypes.proto";
 
-import "google/protobuf/timestamp.proto";
-import "google/api/resource.proto";
+option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
+option java_multiple_files = true;
+option java_outer_classname = "DeviceProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // device capabilities indicate the capabilities of software/hardware
 // as exposed by current firmware of the device. This can help cloud controller
@@ -64,7 +62,7 @@ message DeviceSpec {
   // number and type of pcie functions exposed
   PCIeFunctionsSpec pcie_functions = 5;
   // ovelay routing
-  bool overlay_routing_enabled = 6; 
+  bool overlay_routing_enabled = 6;
   // system name is used as named identifier in protocols (e.g. LLDP)
   string systemname = 7;
   // management network details
@@ -122,15 +120,15 @@ message DeviceStatus {
 // system events happened during device operations
 message SystemEvent {
   // event timestamp
-  google.protobuf.Timestamp event_time  = 1;
+  google.protobuf.Timestamp event_time = 1;
   // name of the event
-  string                    event_description = 2;
+  string event_description = 2;
 }
 
 // critical alerts effecting the health of the system
 message SystemAlert {
   // alert timestamp
-  google.protobuf.Timestamp alert_time  = 1;
+  google.protobuf.Timestamp alert_time = 1;
   // name of the alert
-  string                    alert_description = 2;
+  string alert_description = 2;
 }

--- a/network/cloud/interface.proto
+++ b/network/cloud/interface.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "InterfaceProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "InterfaceProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // interface - ethernet interface (layer2 and layer3 configuration)
 message Interface {
@@ -43,9 +42,9 @@ message InterfaceSpec {
     // layer3 interface configuration
     L3IfSpec l3_if_spec = 5;
     // loopback interface configuration
-    LoopbackIfSpec loopback_if_spec  = 6;
+    LoopbackIfSpec loopback_if_spec = 6;
     // control interface configuration
-    ControlIfSpec control_if_spec   = 7;
+    ControlIfSpec control_if_spec = 7;
     // host facing interface's configuration
     HostIfSpec host_if_spec = 8;
   }
@@ -121,15 +120,15 @@ message HostIfSpec {
   bytes mac_address = 3;
   // interface name (this can be populated from what is obtaine from the driver
   // for easier troublsehooting, or other operations
-  string  ifname = 4;
+  string ifname = 4;
 }
 
 // operational status of uplink interface
 message UplinkIfStatus {
   // hw specific index associated with this uplink, useful for operations
-  int32     hw_if_idx     = 1;
+  int32 hw_if_idx = 1;
   // hw port number is hw identifier of the port, usefor for operations
-  int32     hw_port_number = 2;
+  int32 hw_port_number = 2;
 }
 
 // operational status of loopback interface
@@ -155,16 +154,16 @@ message InterfaceStatus {
   // encoded interface index of this interface
   // (-- api-linter: core::0141::forbidden-types=disabled
   //     aip.dev/not-precedent: interface index is an opaque uint32 value. --)
-  uint32             if_index           = 1;
+  uint32 if_index = 1;
   // operational status of the interface
-  IfStatus           oper_status        = 2;
+  IfStatus oper_status = 2;
   oneof ifstatus {
     // uplink specific status
-    UplinkIfStatus   uplink_if_status   = 3;
+    UplinkIfStatus uplink_if_status = 3;
     // loopback interface specific status
     LoopbackIfStatus loopback_if_status = 4;
     // host interface specific status
-    HostIfStatus     host_if_status     = 5;
+    HostIfStatus host_if_status = 5;
   }
 }
 
@@ -173,17 +172,17 @@ enum IfType {
   // unspecified
   IF_TYPE_UNSPECIFIED = 0;
   // uplink interface
-  IF_TYPE_UPLINK      = 1;
+  IF_TYPE_UPLINK = 1;
   // uplink port-channel interface
-  IF_TYPE_UPLINK_PC   = 2;
+  IF_TYPE_UPLINK_PC = 2;
   // L3 interface
-  IF_TYPE_L3          = 3;
+  IF_TYPE_L3 = 3;
   // loopback interface
-  IF_TYPE_LOOPBACK    = 4;
+  IF_TYPE_LOOPBACK = 4;
   // inband management/control interface
-  IF_TYPE_CONTROL     = 5;
+  IF_TYPE_CONTROL = 5;
   // host visible PF/VF device
-  IF_TYPE_HOST        = 6;
+  IF_TYPE_HOST = 6;
 }
 
 // IfStatus status reflects the operational status of Interface
@@ -193,7 +192,7 @@ enum IfStatus {
   // unknown
   IF_STATUS_UNSPECIFIED = 0;
   // interface is up
-  IF_STATUS_UP          = 1;
+  IF_STATUS_UP = 1;
   // interface is down
-  IF_STATUS_DOWN        = 2;
+  IF_STATUS_DOWN = 2;
 }

--- a/network/cloud/mapping.proto
+++ b/network/cloud/mapping.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "MappingProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "MappingProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // mapping object
 message Mapping {
@@ -41,21 +40,21 @@ message MappingSpec {
   string subnet_name_ref = 3;
   // mapping's destination information
   oneof dstinfo {
-      // if IP is that of local vnic, corresponding vnic id
-      // this is mandatory attribute for local IP mappings
-      string vnic_name_ref = 4;
-      // Tunnel ID of the remote TEP for remote mapping
-      // this is mandatory attribute for remote MAC/IP mappings for
-      // non-ECMP cases
-      string  tunnel_name_ref = 5;
-      // overlay nexthop/TEP group for remote mappings
-      // this is mandatory attribute for remote MAC/IP mappings for ECMP cases
-      string nh_group_name_ref = 6;
+    // if IP is that of local vnic, corresponding vnic id
+    // this is mandatory attribute for local IP mappings
+    string vnic_name_ref = 4;
+    // Tunnel ID of the remote TEP for remote mapping
+    // this is mandatory attribute for remote MAC/IP mappings for
+    // non-ECMP cases
+    string tunnel_name_ref = 5;
+    // overlay nexthop/TEP group for remote mappings
+    // this is mandatory attribute for remote MAC/IP mappings for ECMP cases
+    string nh_group_name_ref = 6;
   }
   // overlay MAC address of this mapping
   bytes mac_addr = 7;
   // fabric encap information specific to this mapping, if any
-  network.opinetcommon.v1alpha1.Encap  encap = 8;
+  network.opinetcommon.v1alpha1.Encap encap = 8;
   // public IP, if overlay IP has corresponding public IP
   network.opinetcommon.v1alpha1.IPAddress public_ip = 9;
   // tag/label/security group of this IP mapping, these tags/labels/SGs can be
@@ -87,7 +86,7 @@ message MappingStatus {
 // L3MappingKey is the 2nd-ary key of the remote IP mapping
 message L3MappingKey {
   // virtual private cloud of the IP mapping
-  string vpc_name_ref  = 1;
+  string vpc_name_ref = 1;
   // private/overlay IP of the mapping
   network.opinetcommon.v1alpha1.IPAddress ip_address = 2;
 }
@@ -115,7 +114,7 @@ message MappingLookupFilter {
     // MAC mapping key
     L2MappingKey mac_key = 5;
     // IP address
-    network.opinetcommon.v1alpha1.IPAddress ip_address  = 6;
+    network.opinetcommon.v1alpha1.IPAddress ip_address = 6;
     // MAC address
     bytes mac_address = 7;
     // VPC id
@@ -128,16 +127,16 @@ enum MappingType {
   // unspecified
   MAPPING_TYPE_UNSPECIFIED = 0;
   // MAPPING_TYPE_VPC is used for regular VPC endpoints and is the default
-  MAPPING_TYPE_VPC         = 1;
+  MAPPING_TYPE_VPC = 1;
   // MAPPING_TYPE_SERVICE is used for mappings that represent service endpoints
-  MAPPING_TYPE_SERVICE     = 2;
+  MAPPING_TYPE_SERVICE = 2;
   // MAPPING_TYPE_LB_VIP is used for mappings that represent load balancer service VIP
-  MAPPING_TYPE_LB_VIP      = 3;
+  MAPPING_TYPE_LB_VIP = 3;
 }
 
 // mapping key type can be L2 or L3
 enum MappingKeyType {
-  // unspecified 
+  // unspecified
   MAPPING_KEY_TYPE_UNSPECIFIED = 0;
   // l2 mapping
   MAPPING_KEY_TYPE_L2 = 1;

--- a/network/cloud/networkpolicy.proto
+++ b/network/cloud/networkpolicy.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "NetworkPolicyProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "NetworkPolicyProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // security policy object
 message SecurityPolicy {
@@ -48,7 +47,7 @@ message SecurityPolicySpec {
   // that is also not set then  default "deny" action is enforced
   // When no policy is configured on subnet and vnic, this knob doesn't
   // apply and traffic is allowed in that case
-  network.opinetcommon.v1alpha1.SecurityRuleAction  default_security_action = 4;
+  network.opinetcommon.v1alpha1.SecurityRuleAction default_security_action = 4;
   // list of security rules
   repeated SecurityRuleInfo rules = 5;
   // PolicyRuleFormat indicates whether the policy is set of flattened rules
@@ -58,7 +57,7 @@ message SecurityPolicySpec {
 
 // SecurityRuleInfo is a single rule in the security policy
 message SecurityRuleInfo {
-  // rule id needed for incremental rule ADD/DEL/UPD 
+  // rule id needed for incremental rule ADD/DEL/UPD
   // (-- api-linter: core::0122::name-suffix=disabled
   //     aip.dev/not-precedent: security rule info is user assigned name for each rule. --)
   string rule_name = 1;
@@ -73,7 +72,7 @@ message SecurityRuleAttrs {
   // packet, the first such matching rule in the policy is picked (i.e., based
   // on the order, first in the list of such matching rules)
   // range:0-65534
-  int32 priority= 1;
+  int32 priority = 1;
   // rule match criteria
   network.opinetcommon.v1alpha1.RuleMatch match = 2;
   // action to take when this rule is matched
@@ -142,11 +141,11 @@ message ALGSpec {
   // ALG specific options, if any
   oneof alg_options {
     // ftp alg options
-    FTPOptions    ftp_options    = 3;
-    // dns alg options 
-    DNSOptions    dns_options    = 4;
+    FTPOptions ftp_options = 3;
+    // dns alg options
+    DNSOptions dns_options = 4;
     // msrpc options
-    MSRPCOptions  msrpc_options  = 5;
+    MSRPCOptions msrpc_options = 5;
     // sunrpc options
     SunRPCOptions sunrpc_options = 6;
   }
@@ -195,8 +194,7 @@ message SecurityRuleSpec {
 }
 
 // operational status of the security rule, if any
-message SecurityRuleStatus {
-}
+message SecurityRuleStatus {}
 
 // security profile object
 message SecurityProfile {
@@ -263,8 +261,7 @@ message SecurityProfileSpec {
 }
 
 // operational status of security profile, if any
-message SecurityProfileStatus {
-}
+message SecurityProfileStatus {}
 
 // PolicyLookupMatch captures all the policy lookup match conditions
 message PolicyLookupMatch {
@@ -310,7 +307,7 @@ message SecurityPolicyLookupRequest {
   // lookup_info is mandatory
   oneof lookup_info {
     // security policy uuid to do the lookup in
-    string policy_name_ref= 1;
+    string policy_name_ref = 1;
     // vnic specific policies will be evaluated when vnic info is provided
     VnicLookupInfo vnic_lookup_info = 2;
   }
@@ -334,7 +331,7 @@ message PolicyLookupResult {
 
 // types of security policies
 enum SecurityPolicyType {
-  // unspecified 
+  // unspecified
   SECURITY_POLICY_TYPE_UNSPECIFIED = 0;
   // UNDERLAY security policy object is singleton object per DSC
   SECURITY_POLICY_TYPE_UNDERLAY = 1;
@@ -349,17 +346,17 @@ enum ALGType {
   // unspecified
   ALG_TYPE_UNSPECIFIED = 0;
   // TFTP ALG
-  ALG_TYPE_TFTP        = 1;
+  ALG_TYPE_TFTP = 1;
   // FTP ALG
-  ALG_TYPE_FTP         = 2;
+  ALG_TYPE_FTP = 2;
   // DNS ALG
-  ALG_TYPE_DNS         = 3;
+  ALG_TYPE_DNS = 3;
   // SUNRPC ALG
-  ALG_TYPE_SUNRPC      = 4;
+  ALG_TYPE_SUNRPC = 4;
   // MSRPC ALG
-  ALG_TYPE_MSRPC       = 5;
+  ALG_TYPE_MSRPC = 5;
   // RTSP ALG
-  ALG_TYPE_RTSP        = 6;
+  ALG_TYPE_RTSP = 6;
 }
 
 // PolicyRuleFormat captures what format is used for the rules in a given
@@ -381,5 +378,5 @@ enum PolicyRuleFormat {
   // as match conditions
   // In this format, ALL the rules must use SrcIPList, DstIPList,
   // PortList, ICMPMatchList attributes only, whereever applicable
-  POLICY_RULE_FORMAT_COMPACT   = 2;
+  POLICY_RULE_FORMAT_COMPACT = 2;
 }

--- a/network/cloud/nexthop.proto
+++ b/network/cloud/nexthop.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "NextHopProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "NextHopProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // nexthop object
 message NextHop {
@@ -26,6 +25,7 @@ message NextHop {
   // status
   NextHopStatus status = 3;
 }
+
 // nexthop specification
 message NextHopSpec {
   // nexthop is different for underlay vs. overlay
@@ -75,7 +75,7 @@ message NextHopStatus {
     // nh is underlay
     UnderlayNextHopStatus underlay_nh_info = 2;
     // nh is overlay
-    OverlayNextHopStatus  overlay_nh_info = 3;
+    OverlayNextHopStatus overlay_nh_info = 3;
   }
 }
 
@@ -148,11 +148,11 @@ enum NextHopType {
   // unspecified
   NEXT_HOP_TYPE_UNSPECIFIED = 0;
   // ip
-  NEXT_HOP_TYPE_IP          = 1;
+  NEXT_HOP_TYPE_IP = 1;
   // underlay
-  NEXT_HOP_TYPE_UNDERLAY    = 2;
+  NEXT_HOP_TYPE_UNDERLAY = 2;
   // overlay
-  NEXT_HOP_TYPE_OVERLAY     = 3;
+  NEXT_HOP_TYPE_OVERLAY = 3;
 }
 
 // type of the nexthop group

--- a/network/cloud/ospf.proto
+++ b/network/cloud/ospf.proto
@@ -7,9 +7,9 @@ syntax = "proto3";
 
 package opi_api.network.cloud.v1alpha1;
 
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
 import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
 option java_multiple_files = true;
@@ -18,182 +18,182 @@ option java_package = "opi_api.network.cloud.v1alpha1";
 
 //  OSPF Config object
 message OspfRouter {
-    option (google.api.resource) = {
-        type: "opi_api.network.cloud.v1alpha1/OspfRouter"
-        pattern: "ospfRouters/{router}"
-        singular: "ospfRouter"
-        plural: "ospfRouters" 
-    };
-    // name is an opaque object handle that is not user settable.
-    // name will be returned with created object
-    // user can only set {resource}_id on the Create request object
-    string name = 1 [(google.api.field_behavior) = IDENTIFIER];
-    // OSPF Configuration specification
-    OSPFSpec spec = 2 [(google.api.field_behavior) = REQUIRED];
-    // OSPF State
-    OSPFOperState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  option (google.api.resource) = {
+    type: "opi_api.network.cloud.v1alpha1/OspfRouter"
+    pattern: "ospfRouters/{router}"
+    singular: "ospfRouter"
+    plural: "ospfRouters"
+  };
+  // name is an opaque object handle that is not user settable.
+  // name will be returned with created object
+  // user can only set {resource}_id on the Create request object
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+  // OSPF Configuration specification
+  OSPFSpec spec = 2 [(google.api.field_behavior) = REQUIRED];
+  // OSPF State
+  OSPFOperState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // OSPF configuration
 message OSPFSpec {
-    // OSPF version v2 or v3 or unspecified assumes v2
-    OSPFVersion ospf_version = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // router ID for this ospf instance
-    string router_id = 2;
-    // Suppress default resolution if true
-    bool suppress_default_resolution = 3;
-    // Redistribution
-    OSPFRedistSpec redist = 4;
-    // Passive Interface name
-    string passive_if = 5;
+  // OSPF version v2 or v3 or unspecified assumes v2
+  OSPFVersion ospf_version = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // router ID for this ospf instance
+  string router_id = 2;
+  // Suppress default resolution if true
+  bool suppress_default_resolution = 3;
+  // Redistribution
+  OSPFRedistSpec redist = 4;
+  // Passive Interface name
+  string passive_if = 5;
 }
 
 // OSPFRedistSpec configuration
 message OSPFRedistSpec {
-    // OSPF redistribution type
-    OSPFRedistType redist_type = 1;
-    // peer enable/disable admin state. if peer is not enabled then local router
-    // must not initiate connections to the neighbor and must not respond to
-    // TCP connections attempts from neighbor
-    network.opinetcommon.v1alpha1.AdminState state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // OSPF local IP address. control plane chooses the local IP address of the
-    // session if an all 0 IP address is provided
-    network.opinetcommon.v1alpha1.IPAddress local_address = 3;
-    // Route-Map
-    string route_map = 4;
-    // Metric type
-    OSPFRedistMetricType metric_type = 5;
-    // Metric value
-    int32 metric = 6;
+  // OSPF redistribution type
+  OSPFRedistType redist_type = 1;
+  // peer enable/disable admin state. if peer is not enabled then local router
+  // must not initiate connections to the neighbor and must not respond to
+  // TCP connections attempts from neighbor
+  network.opinetcommon.v1alpha1.AdminState state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // OSPF local IP address. control plane chooses the local IP address of the
+  // session if an all 0 IP address is provided
+  network.opinetcommon.v1alpha1.IPAddress local_address = 3;
+  // Route-Map
+  string route_map = 4;
+  // Metric type
+  OSPFRedistMetricType metric_type = 5;
+  // Metric value
+  int32 metric = 6;
 }
 
 // OspfArea object
 message OspfArea {
-    option (google.api.resource) = {
-        type : "opi_api.network.cloud.v1alpha1/OspfArea"
-        pattern : "ospfAreas/{areas}"
-        singular: "ospfArea"
-        plural: "ospfAreas" 
-    };
-    // Unique name to identify the area.
-    string name = 1 [(google.api.field_behavior) = IDENTIFIER];
-    // area configuration
-    OspfAreaSpec spec = 2;
-    // area state
-    OSPFOperState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  option (google.api.resource) = {
+    type: "opi_api.network.cloud.v1alpha1/OspfArea"
+    pattern: "ospfAreas/{areas}"
+    singular: "ospfArea"
+    plural: "ospfAreas"
+  };
+  // Unique name to identify the area.
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+  // area configuration
+  OspfAreaSpec spec = 2;
+  // area state
+  OSPFOperState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // OspfAreaSpec configuration
 message OspfAreaSpec {
-    // OSPF Area IP address. control plane chooses the local IP address of the
-    // session if an all 0 IP address is provided, example area zero 0.0.0.0 and
-    // area 1 0.0.0.1
-    network.opinetcommon.v1alpha1.IPAddress area_address = 1;
-    // OSPF Process & context definition for (IPv4)
-    network.opinetcommon.v1alpha1.AdminState state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Network prefix address
-    network.opinetcommon.v1alpha1.IPPrefix network_prefix = 3;
-    // example configuration: area 0 authentication_message_digest
-    string auth_message_digest = 4;
-    // IfNetwork Type
-    OspfIfNetworkType network_type = 5;
+  // OSPF Area IP address. control plane chooses the local IP address of the
+  // session if an all 0 IP address is provided, example area zero 0.0.0.0 and
+  // area 1 0.0.0.1
+  network.opinetcommon.v1alpha1.IPAddress area_address = 1;
+  // OSPF Process & context definition for (IPv4)
+  network.opinetcommon.v1alpha1.AdminState state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Network prefix address
+  network.opinetcommon.v1alpha1.IPPrefix network_prefix = 3;
+  // example configuration: area 0 authentication_message_digest
+  string auth_message_digest = 4;
+  // IfNetwork Type
+  OspfIfNetworkType network_type = 5;
 }
 
 // OspfIfNetwork
 message OspfIfNetwork {
-    option (google.api.resource) = {
-        type : "opi_api.network.cloud.v1alpha1/OspfIfNetwork"
-        pattern : "ospfIfNetworks/{network}"
-        singular: "ospfIfNetwork"
-        plural: "ospfIfNetworks" 
-    };
-    // unique key/identifier of ifnetwork
-    string name = 1 [(google.api.field_behavior) = IDENTIFIER];
-    // OspfIfNetwork configuration
-    OspfIfNetworkSpec spec = 2;
-    // OspfIfNetwork state
-    OSPFOperState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  option (google.api.resource) = {
+    type: "opi_api.network.cloud.v1alpha1/OspfIfNetwork"
+    pattern: "ospfIfNetworks/{network}"
+    singular: "ospfIfNetwork"
+    plural: "ospfIfNetworks"
+  };
+  // unique key/identifier of ifnetwork
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+  // OspfIfNetwork configuration
+  OspfIfNetworkSpec spec = 2;
+  // OspfIfNetwork state
+  OSPFOperState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // OspfIfNetworkSpec configuration
 message OspfIfNetworkSpec {
-    // Network Type Point_To_Point or Broadcast
-    string network_type = 1;
-    // peer enable/disable admin state. if peer is not enabled then local router
-    // must not initiate connections to the neighbor and must not respond to
-    // TCP connections attempts from neighbor
-    network.opinetcommon.v1alpha1.AdminState state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // OSPF local IP address. control plane chooses the local IP address of the
-    // session if an all 0 IP address is provided
-    network.opinetcommon.v1alpha1.IPAddress local_address = 3;
-    // Cost or link metric value is 16 bits and must be validated
-    int32 cost_or_link_metric = 4;
-    // Example: ip ospf message-digest-key 1 md5 intel
-    OSPFMD5Auth md5_auth = 5;
+  // Network Type Point_To_Point or Broadcast
+  string network_type = 1;
+  // peer enable/disable admin state. if peer is not enabled then local router
+  // must not initiate connections to the neighbor and must not respond to
+  // TCP connections attempts from neighbor
+  network.opinetcommon.v1alpha1.AdminState state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // OSPF local IP address. control plane chooses the local IP address of the
+  // session if an all 0 IP address is provided
+  network.opinetcommon.v1alpha1.IPAddress local_address = 3;
+  // Cost or link metric value is 16 bits and must be validated
+  int32 cost_or_link_metric = 4;
+  // Example: ip ospf message-digest-key 1 md5 intel
+  OSPFMD5Auth md5_auth = 5;
 }
 
 // MD5 Auth
 message OSPFMD5Auth {
-    // Message Digest Key value
-    int32 message_digest_key = 1;
-    // Password
-    string password = 2;
+  // Message Digest Key value
+  int32 message_digest_key = 1;
+  // Password
+  string password = 2;
 }
 
 // OSPF Version Number
 enum OSPFVersion {
-    // OSPF Version not specified and assume v2
-    OSPF_VERSION_UNSPECIFIED = 0;
-    // OSPF Version 2
-    OSPF_VERSION_2 = 1;
-    // OSPF Version 3
-    OSPF_VERSION_3 = 2;
+  // OSPF Version not specified and assume v2
+  OSPF_VERSION_UNSPECIFIED = 0;
+  // OSPF Version 2
+  OSPF_VERSION_2 = 1;
+  // OSPF Version 3
+  OSPF_VERSION_3 = 2;
 }
 
 // IfNetwork Types
 enum OspfIfNetworkType {
-    // IfNetwork Type Unspecified
-    OSPF_IF_NETWORK_TYPE_UNSPECIFIED = 0;
-    // Broadcast type
-    OSPF_IF_NETWORK_TYPE_BROADCAST = 1;
-    // Point to Point type
-    OSPF_IF_NETWORK_TYPE_POINT_TO_POINT = 2;
+  // IfNetwork Type Unspecified
+  OSPF_IF_NETWORK_TYPE_UNSPECIFIED = 0;
+  // Broadcast type
+  OSPF_IF_NETWORK_TYPE_BROADCAST = 1;
+  // Point to Point type
+  OSPF_IF_NETWORK_TYPE_POINT_TO_POINT = 2;
 }
 
 // OSPF Redist Metric Type
 enum OSPFRedistMetricType {
-    // Redist Metric Unspecified
-    OSPF_REDIST_METRIC_TYPE_UNSPECIFIED = 0;
-    // Type 1
-    OSPF_REDIST_METRIC_TYPE_1 = 1;
-    // Type 1
-    OSPF_REDIST_METRIC_TYPE_2 = 2;
+  // Redist Metric Unspecified
+  OSPF_REDIST_METRIC_TYPE_UNSPECIFIED = 0;
+  // Type 1
+  OSPF_REDIST_METRIC_TYPE_1 = 1;
+  // Type 1
+  OSPF_REDIST_METRIC_TYPE_2 = 2;
 }
 
 // OSPF Redist Type
 enum OSPFRedistType {
-    // Redist Unspecified
-    OSPF_REDIST_TYPE_UNSPECIFIED = 0;
-    // Connection
-    OSPF_REDIST_TYPE_CONNECTED = 1;
-    // Static
-    OSPF_REDIST_TYPE_STATIC = 2;
-    // BGP
-    OSPF_REDIST_TYPE_BGP = 3;
+  // Redist Unspecified
+  OSPF_REDIST_TYPE_UNSPECIFIED = 0;
+  // Connection
+  OSPF_REDIST_TYPE_CONNECTED = 1;
+  // Static
+  OSPF_REDIST_TYPE_STATIC = 2;
+  // BGP
+  OSPF_REDIST_TYPE_BGP = 3;
 }
 
 // OSPFOperState operational state
 enum OSPFOperState {
-    // unspecified
-    OSPF_OPER_STATE_UNSPECIFIED = 0;
-    // up
-    OSPF_OPER_STATE_UP = 1;
-    // down
-    OSPF_OPER_STATE_DOWN = 2;
-    // going up
-    OSPF_OPER_STATE_GOING_UP = 3;
-    // going down
-    OSPF_OPER_STATE_GOING_DOWN = 4;
-    // activation failed
-    OSPF_OPER_STATE_ACT_FAILED = 5;
+  // unspecified
+  OSPF_OPER_STATE_UNSPECIFIED = 0;
+  // up
+  OSPF_OPER_STATE_UP = 1;
+  // down
+  OSPF_OPER_STATE_DOWN = 2;
+  // going up
+  OSPF_OPER_STATE_GOING_UP = 3;
+  // going down
+  OSPF_OPER_STATE_GOING_DOWN = 4;
+  // activation failed
+  OSPF_OPER_STATE_ACT_FAILED = 5;
 }

--- a/network/cloud/port.proto
+++ b/network/cloud/port.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "PortProto";
+import "google/api/resource.proto";
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "google/protobuf/timestamp.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "PortProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // link level configuration
 message Port {
@@ -51,7 +50,7 @@ message PortSpec {
   bool tx_pause_en = 10;
   // MAC RX pause enable
   bool rx_pause_en = 11;
-  // port loopback mode - MAC or PHY 
+  // port loopback mode - MAC or PHY
   PortLoopBackMode loopback_mode = 12;
   // number of serdes lanes for port (range: 1-4)
   int32 lanes_count = 13;
@@ -62,75 +61,75 @@ message PortStatus {
   // encoded interface index
   // (-- api-linter: core::0141::forbidden-types=disabled
   //     aip.dev/not-precedent: interface index is an opaque uint32 value. --)
-  uint32                     if_index    = 1;
+  uint32 if_index = 1;
   // operational link status
-  PortLinkStatus             link_status = 2;
+  PortLinkStatus link_status = 2;
   // transceiver status
-  PortXcvrStatus             xcvr_status = 3;
+  PortXcvrStatus xcvr_status = 3;
   // internal port link state machine
-  PortLinkFSM                fsm_state   = 4;
+  PortLinkFSM fsm_state = 4;
   // mac associated with the port
-  int32                      mac_id      = 5;
+  int32 mac_id = 5;
   // mac channel associated with the port
-  int32                      mac_ch      = 6;
+  int32 mac_ch = 6;
   // port link state machine record
-  repeated PortLinkFSMRecord fsm_record  = 7;
+  repeated PortLinkFSMRecord fsm_record = 7;
 }
 
 // port link status
 message PortLinkStatus {
   // operational state of port
-  PortOperState    oper_state  = 1;
+  PortOperState oper_state = 1;
   // operational speed of the port
-  PortSpeed        port_speed  = 2;
+  PortSpeed port_speed = 2;
   // operational state of AN
-  bool             autoneg_en  = 3;
+  bool autoneg_en = 3;
   // operational value of NumLanes
-  int32            lanes_count = 4;
+  int32 lanes_count = 4;
   // operational fec type of port
-  PortFecType      fec_type    = 5;
+  PortFecType fec_type = 5;
 }
 
 // transciever status
 message PortXcvrStatus {
   // port number
-  int32         port              = 1;
+  int32 port = 1;
   // xcvr state
-  PortXcvrState state             = 2;
+  PortXcvrState state = 2;
   // xcvr pid
-  PortXcvrPid   pid               = 3;
+  PortXcvrPid pid = 3;
   // media type
-  MediaType     media_type        = 4;
+  MediaType media_type = 4;
   // xcvr sprom
-  bytes         xcvr_sprom        = 5;
+  bytes xcvr_sprom = 5;
   // xcvr vendor name
-  string        vendorname        = 6;
+  string vendorname = 6;
   // xcvr vendor oui
-  string        vendor_oui        = 7;
+  string vendor_oui = 7;
   // encoding type
-  int32         encoding_type     = 8;
+  int32 encoding_type = 8;
   // xcvr serial number
-  string        serial_number     = 9;
+  string serial_number = 9;
   // xcvr part number
-  string        part_number       = 10;
+  string part_number = 10;
   // xcvr firmware revision
-  string        revision          = 11;
+  string revision = 11;
   // xcvr temperature
-  int32         temperature       = 12;
+  int32 temperature = 12;
   // xcvr warning tempreture
-  int32         warn_temperature  = 13;
+  int32 warn_temperature = 13;
   // xcvr alarming tempreture
-  int32         alarm_temperature = 14;
+  int32 alarm_temperature = 14;
 }
 
 // port's link state machine transition record
 message PortLinkFSMRecord {
   // internal port link state machine
-  PortLinkFSM fsm_state                = 1;
+  PortLinkFSM fsm_state = 1;
   // port state time stamp
   google.protobuf.Timestamp state_time = 2;
   // port state duration
-  string duration                      = 3;
+  string duration = 3;
 }
 
 // PortAdminState specifies if the port is enabled (admin up) or disabled (admin down)
@@ -140,19 +139,19 @@ enum PortAdminState {
   // port is admin disabled
   PORT_ADMIN_STATE_DOWN = 1;
   // port is admin enabled
-  PORT_ADMIN_STATE_UP   = 2;
+  PORT_ADMIN_STATE_UP = 2;
 }
 
 // port's transceiver state
 enum PortXcvrState {
   // state - removed
-  PORT_XCVR_STATE_UNSPECIFIED    = 0;
+  PORT_XCVR_STATE_UNSPECIFIED = 0;
   // state - inserted
-  PORT_XCVR_STATE_INSERTED       = 1;
+  PORT_XCVR_STATE_INSERTED = 1;
   // state - pending
-  PORT_XCVR_STATE_PENDING        = 2;
+  PORT_XCVR_STATE_PENDING = 2;
   // state - sprom read
-  PORT_XCVR_STATE_SPROM_READ     = 3;
+  PORT_XCVR_STATE_SPROM_READ = 3;
   // state - sprom read error
   PORT_XCVR_STATE_SPROM_READ_ERR = 4;
 }
@@ -160,11 +159,11 @@ enum PortXcvrState {
 // transciever product id
 enum PortXcvrPid {
   // unspecified
-  PORT_XCVR_PID_UNSPECIFIED      = 0;
+  PORT_XCVR_PID_UNSPECIFIED = 0;
 
   // Copper
   // QSFP 100G CR4
-  PORT_XCVR_PID_QSFP_100G_CR4    = 1;
+  PORT_XCVR_PID_QSFP_100G_CR4 = 1;
   // QSFP 40G CR4
   PORT_XCVR_PID_QSFP_40GBASE_CR4 = 2;
   // 25G CR S
@@ -174,23 +173,23 @@ enum PortXcvrPid {
   // 25G CR N
   PORT_XCVR_PID_SFP_25GBASE_CR_N = 5;
   // 50G CR2 FC
-  PORT_XCVR_PID_QSFP_50G_CR2_FC  = 6;
+  PORT_XCVR_PID_QSFP_50G_CR2_FC = 6;
   // 50G CR2
-  PORT_XCVR_PID_QSFP_50G_CR2     = 7;
+  PORT_XCVR_PID_QSFP_50G_CR2 = 7;
   // 200G CR4
-  PORT_XCVR_PID_QSFP_200G_CR4    = 8;
+  PORT_XCVR_PID_QSFP_200G_CR4 = 8;
 
   // Fiber
   // QSFP 100G AOC
-  PORT_XCVR_PID_QSFP_100G_AOC    = 50;
+  PORT_XCVR_PID_QSFP_100G_AOC = 50;
   // QSFP 100G ACC
-  PORT_XCVR_PID_QSFP_100G_ACC    = 51;
+  PORT_XCVR_PID_QSFP_100G_ACC = 51;
   // QSFP 100G SR4
-  PORT_XCVR_PID_QSFP_100G_SR4    = 52;
+  PORT_XCVR_PID_QSFP_100G_SR4 = 52;
   // QSFP 100G LR4
-  PORT_XCVR_PID_QSFP_100G_LR4    = 53;
+  PORT_XCVR_PID_QSFP_100G_LR4 = 53;
   // QSFP 100G ER4
-  PORT_XCVR_PID_QSFP_100G_ER4    = 54;
+  PORT_XCVR_PID_QSFP_100G_ER4 = 54;
   // QSFP 40G ER4
   PORT_XCVR_PID_QSFP_40GBASE_ER4 = 55;
   // QSFP 40G SR4
@@ -200,35 +199,35 @@ enum PortXcvrPid {
   // QSFP 40G AOC
   PORT_XCVR_PID_QSFP_40GBASE_AOC = 58;
   // SFP 25G SR
-  PORT_XCVR_PID_SFP_25GBASE_SR   = 59;
+  PORT_XCVR_PID_SFP_25GBASE_SR = 59;
   // SFP 25G LR
-  PORT_XCVR_PID_SFP_25GBASE_LR   = 60;
+  PORT_XCVR_PID_SFP_25GBASE_LR = 60;
   // SFP 25G ER
-  PORT_XCVR_PID_SFP_25GBASE_ER   = 61;
+  PORT_XCVR_PID_SFP_25GBASE_ER = 61;
   // SFP 25G AOC
-  PORT_XCVR_PID_SFP_25GBASE_AOC  = 62;
+  PORT_XCVR_PID_SFP_25GBASE_AOC = 62;
   // SFP 10G SR
-  PORT_XCVR_PID_SFP_10GBASE_SR   = 63;
+  PORT_XCVR_PID_SFP_10GBASE_SR = 63;
   // SFP 10G LR
-  PORT_XCVR_PID_SFP_10GBASE_LR   = 64;
+  PORT_XCVR_PID_SFP_10GBASE_LR = 64;
   // SFP 10G LRM
-  PORT_XCVR_PID_SFP_10GBASE_LRM  = 65;
+  PORT_XCVR_PID_SFP_10GBASE_LRM = 65;
   // SFP 10G ER
-  PORT_XCVR_PID_SFP_10GBASE_ER   = 66;
+  PORT_XCVR_PID_SFP_10GBASE_ER = 66;
   // SFP 10G AOC
-  PORT_XCVR_PID_SFP_10GBASE_AOC  = 67;
+  PORT_XCVR_PID_SFP_10GBASE_AOC = 67;
   // SFP 10G CU
-  PORT_XCVR_PID_SFP_10GBASE_CU   = 68;
+  PORT_XCVR_PID_SFP_10GBASE_CU = 68;
   // QSFP 100G CXWDM4
-  PORT_XCVR_PID_QSFP_100G_CWDM4  = 69;
+  PORT_XCVR_PID_QSFP_100G_CWDM4 = 69;
   // QSFP 100G PSM4
-  PORT_XCVR_PID_QSFP_100G_PSM4   = 70;
+  PORT_XCVR_PID_QSFP_100G_PSM4 = 70;
   // SFP 125G ACC
-  PORT_XCVR_PID_SFP_25GBASE_ACC  = 71;
+  PORT_XCVR_PID_SFP_25GBASE_ACC = 71;
   // SFP 10G BASE T
-  PORT_XCVR_PID_SFP_10GBASE_T    = 72;
+  PORT_XCVR_PID_SFP_10GBASE_T = 72;
   // SFP 100G BASE T
-  PORT_XCVR_PID_SFP_1000BASE_T   = 73;
+  PORT_XCVR_PID_SFP_1000BASE_T = 73;
 }
 
 // port's media type
@@ -236,9 +235,9 @@ enum MediaType {
   // media not connected
   MEDIA_TYPE_UNSPECIFIED = 0;
   // copper cable
-  MEDIA_TYPE_COPPER      = 1;
+  MEDIA_TYPE_COPPER = 1;
   // fiber cable
-  MEDIA_TYPE_FIBER       = 2;
+  MEDIA_TYPE_FIBER = 2;
 }
 
 // PortOperState reflects the current status of the port
@@ -246,9 +245,9 @@ enum PortOperState {
   // unknown
   PORT_OPER_STATE_UNSPECIFIED = 0;
   // port is linked up
-  PORT_OPER_STATE_UP          = 1;
+  PORT_OPER_STATE_UP = 1;
   // port link status is down
-  PORT_OPER_STATE_DOWN        = 2;
+  PORT_OPER_STATE_DOWN = 2;
 }
 
 // port pause type
@@ -256,63 +255,63 @@ enum PortPauseType {
   // Disable Pause
   PORT_PAUSE_TYPE_UNSPECIFIED = 0;
   // Link level pause
-  PORT_PAUSE_TYPE_LINK        = 1;
+  PORT_PAUSE_TYPE_LINK = 1;
   // PFC
-  PORT_PAUSE_TYPE_PFC         = 2;
+  PORT_PAUSE_TYPE_PFC = 2;
 }
 
 // port link state
 enum PortLinkFSM {
   // unspecified1
-  PORT_LINK_FSM_UNSPECIFIED             =  0;
+  PORT_LINK_FSM_UNSPECIFIED = 0;
   // enabled
-  PORT_LINK_FSM_ENABLED                 =  1;
+  PORT_LINK_FSM_ENABLED = 1;
   // auto negotiation configured
-  PORT_LINK_FSM_AN_CFG                  =  2;
+  PORT_LINK_FSM_AN_CFG = 2;
   // auto negotiation disabled
-  PORT_LINK_FSM_AN_DISABLED             =  3;
+  PORT_LINK_FSM_AN_DISABLED = 3;
   // auto negotiation started
-  PORT_LINK_FSM_AN_START                =  4;
+  PORT_LINK_FSM_AN_START = 4;
   // auto negotiation signal detect
-  PORT_LINK_FSM_AN_SIGNAL_DETECT        =  5;
+  PORT_LINK_FSM_AN_SIGNAL_DETECT = 5;
   // auto negotiation wait HCD
-  PORT_LINK_FSM_AN_WAIT_HCD             =  6;
+  PORT_LINK_FSM_AN_WAIT_HCD = 6;
   // auto negotiation complete
-  PORT_LINK_FSM_AN_COMPLETE             =  7;
+  PORT_LINK_FSM_AN_COMPLETE = 7;
   // seredes configured
-  PORT_LINK_FSM_SERDES_CFG              =  8;
+  PORT_LINK_FSM_SERDES_CFG = 8;
   // serdes ready
-  PORT_LINK_FSM_WAIT_SERDES_RDY         =  9;
+  PORT_LINK_FSM_WAIT_SERDES_RDY = 9;
   // mac configured
-  PORT_LINK_FSM_MAC_CFG                 = 10;
+  PORT_LINK_FSM_MAC_CFG = 10;
   // signal detected
-  PORT_LINK_FSM_SIGNAL_DETECT           = 11;
+  PORT_LINK_FSM_SIGNAL_DETECT = 11;
   // auto negotiation dfe tuning
-  PORT_LINK_FSM_AN_DFE_TUNING           = 12;
+  PORT_LINK_FSM_AN_DFE_TUNING = 12;
   // dfe tuning enabled
-  PORT_LINK_FSM_DFE_TUNING              = 13;
+  PORT_LINK_FSM_DFE_TUNING = 13;
   // dfe disabled
-  PORT_LINK_FSM_DFE_DISABLED            = 14;
+  PORT_LINK_FSM_DFE_DISABLED = 14;
   // dfe start ical
-  PORT_LINK_FSM_DFE_START_ICAL          = 15;
+  PORT_LINK_FSM_DFE_START_ICAL = 15;
   // dfe wait ical
-  PORT_LINK_FSM_DFE_WAIT_ICAL           = 16;
+  PORT_LINK_FSM_DFE_WAIT_ICAL = 16;
   // dfe start pcal
-  PORT_LINK_FSM_DFE_START_PCAL          = 17;
+  PORT_LINK_FSM_DFE_START_PCAL = 17;
   // dfe wait pcal
-  PORT_LINK_FSM_DFE_WAIT_PCAL           = 18;
+  PORT_LINK_FSM_DFE_WAIT_PCAL = 18;
   // dfe pcal continuous
-  PORT_LINK_FSM_DFE_PCAL_CONTINUOUS     = 19;
+  PORT_LINK_FSM_DFE_PCAL_CONTINUOUS = 19;
   // clear mac remote faults
   PORT_LINK_FSM_CLEAR_MAC_REMOTE_FAULTS = 20;
   // wait mac sync
-  PORT_LINK_FSM_WAIT_MAC_SYNC           = 21;
+  PORT_LINK_FSM_WAIT_MAC_SYNC = 21;
   // mac faults cleared
-  PORT_LINK_FSM_WAIT_MAC_FAULTS_CLEAR   = 22;
+  PORT_LINK_FSM_WAIT_MAC_FAULTS_CLEAR = 22;
   // wait phy link up
-  PORT_LINK_FSM_WAIT_PHY_LINK_UP        = 23;
+  PORT_LINK_FSM_WAIT_PHY_LINK_UP = 23;
   // link up
-  PORT_LINK_FSM_UP                      = 24;
+  PORT_LINK_FSM_UP = 24;
 }
 
 // loop back mode configuration
@@ -330,9 +329,9 @@ enum PortFecType {
   // Disable FEC
   PORT_FEC_TYPE_UNSPECIFIED = 0;
   // FireCode (FC) FEC
-  PORT_FEC_TYPE_FC          = 1;
+  PORT_FEC_TYPE_FC = 1;
   // ReedSolomon (RS) FEC
-  PORT_FEC_TYPE_RS          = 2;
+  PORT_FEC_TYPE_RS = 2;
 }
 
 // port type - date or management
@@ -340,9 +339,9 @@ enum PortType {
   // unspecified
   PORT_TYPE_UNSPECIFIED = 0;
   // data ethernet
-  PORT_TYPE_ETH         = 1;
+  PORT_TYPE_ETH = 1;
   // management ethernet
-  PORT_TYPE_ETH_MGMT    = 2;
+  PORT_TYPE_ETH_MGMT = 2;
 }
 
 // PortSpeed specifies the speed of the port
@@ -350,23 +349,23 @@ enum PortSpeed {
   // unconfigured
   PORT_SPEED_UNSPECIFIED = 0;
   // port speed is 10Mbps
-  PORT_SPEED_10M         = 1;
+  PORT_SPEED_10M = 1;
   // port speed is 100Mbps
-  PORT_SPEED_100M        = 2;
+  PORT_SPEED_100M = 2;
   // port speed is 1Gbps
-  PORT_SPEED_1G          = 3;
+  PORT_SPEED_1G = 3;
   // port speed is 10Gbps
-  PORT_SPEED_10G         = 4;
+  PORT_SPEED_10G = 4;
   // port speed is 25Gbps
-  PORT_SPEED_25G         = 5;
+  PORT_SPEED_25G = 5;
   // port speed is 40Gbps
-  PORT_SPEED_40G         = 6;
+  PORT_SPEED_40G = 6;
   // port speed is 50Gbps
-  PORT_SPEED_50G         = 7;
+  PORT_SPEED_50G = 7;
   // port speed is 100Gbps
-  PORT_SPEED_100G        = 8;
+  PORT_SPEED_100G = 8;
   // port speed is 200Gbps
-  PORT_SPEED_200G        = 9;
+  PORT_SPEED_200G = 9;
   // port speed is 400Gbps
-  PORT_SPEED_400G        = 10;
+  PORT_SPEED_400G = 10;
 }

--- a/network/cloud/route.proto
+++ b/network/cloud/route.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "RouteProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "RouteProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // route table object
 message RouteTable {
@@ -190,8 +189,7 @@ message RouteSpec {
 }
 
 // operational status of the route, if any
-message RouteStatus {
-}
+message RouteStatus {}
 
 // RouteClass captures different types/classes of routes
 enum RouteClass {
@@ -204,4 +202,3 @@ enum RouteClass {
   // VPC internal routes
   ROUTE_CLASS_VPC = 3;
 }
-

--- a/network/cloud/subnet.proto
+++ b/network/cloud/subnet.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "SubnetProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "SubnetProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // subnet object
 message Subnet {
@@ -98,7 +97,7 @@ message SubnetSpec {
   string ingress_default_sg_policy_name_ref = 18;
   // default egress stateful security policy for this subnet
   // if configured, is the 1st policy evaluated before other security polices on a given vnic
-  string  egress_default_sg_policy_name_ref = 19;
+  string egress_default_sg_policy_name_ref = 19;
   // remote_subnet, if set, indicates that the subnet does not have any IP
   // mappings in local pod and such subnets are used to program all remote
   // pod IP mappings behind it

--- a/network/cloud/tunnel.proto
+++ b/network/cloud/tunnel.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "TunnelProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "TunnelProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // tunnel object
 message Tunnel {
@@ -87,15 +86,15 @@ enum TunnelType {
   // unspecified
   TUNNEL_TYPE_UNSPECIFIED = 0;
   // tunnel type for Internet Gateway
-  TUNNEL_TYPE_IGW         = 1;
+  TUNNEL_TYPE_IGW = 1;
   // tunnel type for east-traffic workloads with in a data center
-  TUNNEL_TYPE_WORKLOAD    = 2;
+  TUNNEL_TYPE_WORKLOAD = 2;
   // tunnel type for inter data center traffic
-  TUNNEL_TYPE_INTER_DC    = 3;
+  TUNNEL_TYPE_INTER_DC = 3;
   // tunnel type for provider services
-  TUNNEL_TYPE_SERVICE     = 4;
+  TUNNEL_TYPE_SERVICE = 4;
   // tunnel pointing to an intermediate Virtual Network Function (VNF) devices
-  TUNNEL_TYPE_VNF         = 5;
+  TUNNEL_TYPE_VNF = 5;
   // tunnel type ipsec
-  TUNNEL_TYPE_IPSEC       = 6;
+  TUNNEL_TYPE_IPSEC = 6;
 }

--- a/network/cloud/underlayroute.proto
+++ b/network/cloud/underlayroute.proto
@@ -1,19 +1,18 @@
 // Copyright (c) 2023 Pensando, AMD Inc, or its subsidiaries.
 // protobuf specification for underlay (i.e. control plane) route table
-// Underlayroute object differ from overlay/tenant Route  object because 
+// Underlayroute object differ from overlay/tenant Route  object because
 // next hop is very different, doesn't require priority, classification, metering, etc.
 
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "UnderlayRouteProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "UnderlayRouteProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // Underlay Route can be static or dynamic underlay route
 message UnderlayRoute {
@@ -51,7 +50,7 @@ message UnderlayRouteSpec {
 // Underlay Route status for a control plane static or dynamic route
 message UnderlayRouteStatus {
   // route table id this route belongs to
-  int32 route_table_name_ref  = 1;
+  int32 route_table_name_ref = 1;
   // destination address
   network.opinetcommon.v1alpha1.IPPrefix dest_prefix = 2;
   // next-hop address

--- a/network/cloud/vnic.proto
+++ b/network/cloud/vnic.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "VnicProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "VnicProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // vnic is a generic abstraction representing tenant workload's interface
 // tenant workload could be a VM, container or bare-metal.  VNIC is identified
@@ -39,7 +38,7 @@ message VnicSpec {
   // overlay MAC of this VNIC
   bytes mac_address = 3;
   // enable or disable reverse path checks while rx/tx traffic from/to this vnic
-  bool  source_guard_enable = 4;
+  bool source_guard_enable = 4;
   // fabric encap information to be used for traffic originated from this vnic
   network.opinetcommon.v1alpha1.Encap fabric_encap = 5;
   // VNFs (virtual network functions are workloads that implement network
@@ -64,29 +63,29 @@ message VnicSpec {
   }
   // max_sessions, if set, is total number of active sessions (across all
   // protocols) allowed from/to this vnic; zero means unlimited
-  int32  max_sessions = 13;
+  int32 max_sessions = 13;
   // guest workload's MAC in rx/tx direction is rewritten with this mac if non zero
   bytes public_mac_address = 14;
   // if allow_internet_access is set to false and traffic from the vnic hits a
   // route of class ROUTE_CLASS_INTERNET, then traffic is dropped. To allow
   // Internet connectivity for the vnic, AllowInternetAccess must be set to
   // true
-  bool allow_internet_access   = 15;
+  bool allow_internet_access = 15;
   // max_cps, if non-zero, is the maximum no. of connections per second (cps)
   // allowed for this vnic and if cps exceeds this configured limit all
   // new connections will get dropped; zero means unlimited
   int32 max_cps = 16;
   // CPS burst to be absorbed when CPS exceeds MaxCPS; zero means
   // no burst is allowed
-  int32  cps_burst = 17;
+  int32 cps_burst = 17;
   // multiple vnics can be created with same MAC but only of them can be primary
   // VNIC and all 2nd-ary vnics refer to the primary vnic, both primary and
   // secondary vnic can have one or more local IP mappings behind them
-  string  primary_vnic_name_ref = 18;
+  string primary_vnic_name_ref = 18;
   // identifier of the IPv4 route table to be used
   string v4_route_table_name_ref = 19;
   // identifier of the IPv6 route table to be used, if any
-  string  v6_route_table_name_ref = 20;
+  string v6_route_table_name_ref = 20;
   // vnic if assigned a VIP in the underlay, can be used as
   // outer encap source IP, if configured, for traffic going to certain vpc
   // private service endpoints

--- a/network/cloud/vpc.proto
+++ b/network/cloud/vpc.proto
@@ -4,14 +4,13 @@
 syntax = "proto3";
 package opi_api.network.cloud.v1alpha1;
 
-option java_package = "opi_api.network.cloud.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "VpcProto";
+import "google/api/resource.proto";
+import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/network/cloud/v1alpha1/gen/go";
-
-import "network/opinetcommon/networktypes.proto";
-import "google/api/resource.proto";
+option java_multiple_files = true;
+option java_outer_classname = "VpcProto";
+option java_package = "opi_api.network.cloud.v1alpha1";
 
 // Virtual Private Cloud object
 message Vpc {
@@ -104,17 +103,16 @@ message VPCPeerSpec {
 }
 
 // operational status of a VPC peering, if any
-message VPCPeerStatus {
-}
+message VPCPeerStatus {}
 
 // type of the virtual private cloud
 enum VPCType {
   // unspecified
   VPC_TYPE_UNSPECIFIED = 0;
   // underlay
-  VPC_TYPE_UNDERLAY    = 1;
+  VPC_TYPE_UNDERLAY = 1;
   // tenant
-  VPC_TYPE_TENANT      = 2;
+  VPC_TYPE_TENANT = 2;
   // control
-  VPC_TYPE_CONTROL     = 3;
+  VPC_TYPE_CONTROL = 3;
 }

--- a/network/evpn-gw/component.proto
+++ b/network/evpn-gw/component.proto
@@ -9,34 +9,34 @@ syntax = "proto3";
 
 package opi_api.network.evpn_gw.v1alpha1;
 
+import "google/api/field_behavior.proto";
+
 option go_package = "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go";
-option java_package = "opi_api.network.evpn_gw.v1alpha1";
 option java_multiple_files = true;
 option java_outer_classname = "ComponentProto";
-
-import "google/api/field_behavior.proto";
+option java_package = "opi_api.network.evpn_gw.v1alpha1";
 
 // Component represents a subscribed component (e.g. FRR component, Linux component etc...)
 // (-- api-linter: core::0123::resource-annotation=disabled
-//     aip.dev/not-precedent: The name here is not the unique identifier of a DB object 
+//     aip.dev/not-precedent: The name here is not the unique identifier of a DB object
 //                            just the name of the component that is subscribed. --)
 message Component {
-    // Component's name
-    string name       = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Component's status
-    CompStatus status = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Component's details in the form of json string
-    string details    = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component's name
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component's status
+  CompStatus status = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Component's details in the form of json string
+  string details = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CompStatus reflects the status of a component
 enum CompStatus {
-    // component status is "unspecified"
-    COMP_STATUS_UNSPECIFIED = 0;
-    // component status is "pending"
-    COMP_STATUS_PENDING     = 1;
-    // component status is "success"
-    COMP_STATUS_SUCCESS     = 2;
-    // component status is "error"
-    COMP_STATUS_ERROR       = 3;
+  // component status is "unspecified"
+  COMP_STATUS_UNSPECIFIED = 0;
+  // component status is "pending"
+  COMP_STATUS_PENDING = 1;
+  // component status is "success"
+  COMP_STATUS_SUCCESS = 2;
+  // component status is "error"
+  COMP_STATUS_ERROR = 3;
 }

--- a/network/evpn-gw/l2_xpu_infra_mgr.proto
+++ b/network/evpn-gw/l2_xpu_infra_mgr.proto
@@ -15,341 +15,328 @@ syntax = "proto3";
 
 package opi_api.network.evpn_gw.v1alpha1;
 
-option go_package = "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go";
-option java_package = "opi_api.network.evpn_gw.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "L2XpuInfraMgrProto";
-
-import "network/opinetcommon/networktypes.proto";
-import "network/evpn-gw/component.proto";
-
 import "google/api/annotations.proto";
 import "google/api/client.proto";
-import "google/protobuf/empty.proto";
 import "google/api/field_behavior.proto";
-import "google/protobuf/field_mask.proto";
 import "google/api/resource.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+import "network/evpn-gw/component.proto";
+import "network/opinetcommon/networktypes.proto";
+
+option go_package = "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go";
+option java_multiple_files = true;
+option java_outer_classname = "L2XpuInfraMgrProto";
+option java_package = "opi_api.network.evpn_gw.v1alpha1";
 
 // Management of LogicalBridge Resources
 service LogicalBridgeService {
-    // Create a Logical Bridge
-    rpc CreateLogicalBridge(CreateLogicalBridgeRequest) returns (LogicalBridge){
-        option (google.api.http) = {
-          post: "/v1/logicalBridges"
-          body: "logical_bridge"
-        };
-        option (google.api.method_signature) = "logical_bridge,logical_bridge_id";
-    }
-    // List Logical Bridges
-    rpc ListLogicalBridges(ListLogicalBridgesRequest) returns (ListLogicalBridgesResponse){
-        option (google.api.http) = {
-          get: "/v1/logicalBridges"
-        };
-    }
-    // Retrieve a Logical Bridge
-    rpc GetLogicalBridge(GetLogicalBridgeRequest) returns (LogicalBridge){
-        option (google.api.http) = {
-          get: "/v1/{name=logicalBridges/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Delete a Logical Bridge
-    rpc DeleteLogicalBridge(DeleteLogicalBridgeRequest) returns (google.protobuf.Empty){
-        option (google.api.http) = {
-          delete: "/v1/{name=logicalBridges/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Update a Logical Bridge
-    rpc UpdateLogicalBridge(UpdateLogicalBridgeRequest) returns (LogicalBridge){
-        option (google.api.http) = {
-          patch: "/v1/{logical_bridge.name=logicalBridges/*}"
-          body: "logical_bridge"
-        };
-        option (google.api.method_signature) = "logical_bridge,update_mask";
-    }
+  // Create a Logical Bridge
+  rpc CreateLogicalBridge(CreateLogicalBridgeRequest) returns (LogicalBridge) {
+    option (google.api.http) = {
+      post: "/v1/logicalBridges"
+      body: "logical_bridge"
+    };
+    option (google.api.method_signature) = "logical_bridge,logical_bridge_id";
+  }
+  // List Logical Bridges
+  rpc ListLogicalBridges(ListLogicalBridgesRequest) returns (ListLogicalBridgesResponse) {
+    option (google.api.http) = {get: "/v1/logicalBridges"};
+  }
+  // Retrieve a Logical Bridge
+  rpc GetLogicalBridge(GetLogicalBridgeRequest) returns (LogicalBridge) {
+    option (google.api.http) = {get: "/v1/{name=logicalBridges/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Delete a Logical Bridge
+  rpc DeleteLogicalBridge(DeleteLogicalBridgeRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=logicalBridges/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Update a Logical Bridge
+  rpc UpdateLogicalBridge(UpdateLogicalBridgeRequest) returns (LogicalBridge) {
+    option (google.api.http) = {
+      patch: "/v1/{logical_bridge.name=logicalBridges/*}"
+      body: "logical_bridge"
+    };
+    option (google.api.method_signature) = "logical_bridge,update_mask";
+  }
 }
 
 // Management of BridgePort resources
 service BridgePortService {
-    // Create a Bridge Port
-    rpc CreateBridgePort(CreateBridgePortRequest) returns (BridgePort){
-        option (google.api.http) = {
-          post: "/v1/bridgePorts"
-          body: "bridge_port"
-        };
-        option (google.api.method_signature) = "bridge_port,bridge_port_id";
-    }
-    // List Bridge Ports
-    rpc ListBridgePorts(ListBridgePortsRequest) returns (ListBridgePortsResponse){
-        option (google.api.http) = {
-          get: "/v1/bridgePorts"
-        };
-    }
-    // Retrieve a Bridge Port
-    rpc GetBridgePort(GetBridgePortRequest) returns (BridgePort){
-        option (google.api.http) = {
-          get: "/v1/{name=bridgePorts/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Delete a Bridge Port
-    rpc DeleteBridgePort(DeleteBridgePortRequest) returns (google.protobuf.Empty){
-        option (google.api.http) = {
-          delete: "/v1/{name=bridgePorts/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Update a Bridge Port
-    rpc UpdateBridgePort(UpdateBridgePortRequest) returns (BridgePort){
-        option (google.api.http) = {
-          patch: "/v1/{bridge_port.name=bridgePorts/*}"
-          body: "bridge_port"
-        };
-        option (google.api.method_signature) = "bridge_port,update_mask";
-    }
+  // Create a Bridge Port
+  rpc CreateBridgePort(CreateBridgePortRequest) returns (BridgePort) {
+    option (google.api.http) = {
+      post: "/v1/bridgePorts"
+      body: "bridge_port"
+    };
+    option (google.api.method_signature) = "bridge_port,bridge_port_id";
+  }
+  // List Bridge Ports
+  rpc ListBridgePorts(ListBridgePortsRequest) returns (ListBridgePortsResponse) {
+    option (google.api.http) = {get: "/v1/bridgePorts"};
+  }
+  // Retrieve a Bridge Port
+  rpc GetBridgePort(GetBridgePortRequest) returns (BridgePort) {
+    option (google.api.http) = {get: "/v1/{name=bridgePorts/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Delete a Bridge Port
+  rpc DeleteBridgePort(DeleteBridgePortRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=bridgePorts/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Update a Bridge Port
+  rpc UpdateBridgePort(UpdateBridgePortRequest) returns (BridgePort) {
+    option (google.api.http) = {
+      patch: "/v1/{bridge_port.name=bridgePorts/*}"
+      body: "bridge_port"
+    };
+    option (google.api.method_signature) = "bridge_port,update_mask";
+  }
 }
 
 // Logical Bridge network configuration and status
 message LogicalBridge {
-    option (google.api.resource) = {
-      type: "opi_api.network.evpn_gw.v1alpha1/LogicalBridge"
-      pattern: "logicalBridges/{logical_bridge}"
-      singular: "logicalBridge"
-      plural: "logicalBridges"
-    };
-    // The resource name of the Logical Bridge.
-    // "name" is an opaque object handle that is not user settable.
-    // "name" will be returned with created object
-    // user can only set {resource}_id on the Create request object
-    // Format: logicalBridges/{logical_bridge}
-    string name                = 1 [(google.api.field_behavior) = IDENTIFIER];
+  option (google.api.resource) = {
+    type: "opi_api.network.evpn_gw.v1alpha1/LogicalBridge"
+    pattern: "logicalBridges/{logical_bridge}"
+    singular: "logicalBridge"
+    plural: "logicalBridges"
+  };
+  // The resource name of the Logical Bridge.
+  // "name" is an opaque object handle that is not user settable.
+  // "name" will be returned with created object
+  // user can only set {resource}_id on the Create request object
+  // Format: logicalBridges/{logical_bridge}
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
-    // Logical Bridge network configuration
-    LogicalBridgeSpec spec     = 2 [(google.api.field_behavior) = REQUIRED];
-    // Logical Bridge network status
-    LogicalBridgeStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Logical Bridge network configuration
+  LogicalBridgeSpec spec = 2 [(google.api.field_behavior) = REQUIRED];
+  // Logical Bridge network status
+  LogicalBridgeStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Logical Bridge network configuration
 message LogicalBridgeSpec {
-    // the VLAN of the L2 domain
-    // (-- api-linter: core::0141::forbidden-types=disabled
-    //     aip.dev/not-precedent: vlan cannot be negative number. --)
-    uint32 vlan_id                                        = 1 [(google.api.field_behavior) = REQUIRED];
-    //VXLAN VNI for the L2 EVPN. Also used as EVPN route target
-    // (-- api-linter: core::0141::forbidden-types=disabled
-    //     aip.dev/not-precedent: vni cannot be negative number. --)
-    optional uint32 vni                                   = 2 [(google.api.field_behavior) = OPTIONAL];
-    // IPv4 or IPv6 IP address prefix for the VXLAN TEP
-    network.opinetcommon.v1alpha1.IPPrefix vtep_ip_prefix = 3 [(google.api.field_behavior) = OPTIONAL];
+  // the VLAN of the L2 domain
+  // (-- api-linter: core::0141::forbidden-types=disabled
+  //     aip.dev/not-precedent: vlan cannot be negative number. --)
+  uint32 vlan_id = 1 [(google.api.field_behavior) = REQUIRED];
+  //VXLAN VNI for the L2 EVPN. Also used as EVPN route target
+  // (-- api-linter: core::0141::forbidden-types=disabled
+  //     aip.dev/not-precedent: vni cannot be negative number. --)
+  optional uint32 vni = 2 [(google.api.field_behavior) = OPTIONAL];
+  // IPv4 or IPv6 IP address prefix for the VXLAN TEP
+  network.opinetcommon.v1alpha1.IPPrefix vtep_ip_prefix = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // operational status of a Logical Bridge
 message LogicalBridgeStatus {
-    // operational state of a Logical Bridge
-    LBOperStatus oper_status = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // status of the components
-    repeated Component components = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // operational state of a Logical Bridge
+  LBOperStatus oper_status = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // status of the components
+  repeated Component components = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateLogicalBridgeRequest structure
 message CreateLogicalBridgeRequest {
-    // The ID to use for the logical bridge, which will become the final component of
-    // the logical bridge's resource name.
-    //
-    // This value should be 4-63 characters, and valid characters
-    // are /[a-z][0-9]-/.
-    // If this is not provided the system will auto-generate it.
-    string logical_bridge_id     = 1 [(google.api.field_behavior) = OPTIONAL];
+  // The ID to use for the logical bridge, which will become the final component of
+  // the logical bridge's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  // If this is not provided the system will auto-generate it.
+  string logical_bridge_id = 1 [(google.api.field_behavior) = OPTIONAL];
 
-    // The logical bridge to create
-    LogicalBridge logical_bridge = 2 [(google.api.field_behavior) = REQUIRED];
+  // The logical bridge to create
+  LogicalBridge logical_bridge = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListLogicalBridgesRequest structure
 message ListLogicalBridgesRequest {
-    // page size of list request
-    int32 page_size   = 1 [(google.api.field_behavior) = OPTIONAL];
-    // page token of list request
-    string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // page size of list request
+  int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // page token of list request
+  string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListLogicalBridgesResponse structure
 message ListLogicalBridgesResponse {
-    // List of all the logical bridges
-    repeated LogicalBridge logical_bridges = 1;
-    // Next page token of list response
-    string next_page_token                 = 2;
+  // List of all the logical bridges
+  repeated LogicalBridge logical_bridges = 1;
+  // Next page token of list response
+  string next_page_token = 2;
 }
 
 // GetLogicalBridgeRequest structure
 message GetLogicalBridgeRequest {
-    // The name of the logical bridge to retrieve
-    // Format: logicalBridges/{logical_bridge}
-    string name = 1 [
-      (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/LogicalBridge"
-    ];
+  // The name of the logical bridge to retrieve
+  // Format: logicalBridges/{logical_bridge}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/LogicalBridge"
+  ];
 }
 
 // DeleteLogicalBridgeRequest structure
 message DeleteLogicalBridgeRequest {
-    // The name of the logical bridge to retrieve
-    // Format: logicalBridges/{logical_bridge}
-    string name = 1 [
-      (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/LogicalBridge"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The name of the logical bridge to retrieve
+  // Format: logicalBridges/{logical_bridge}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/LogicalBridge"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // UpdateLogicalBridgeRequest structure
 message UpdateLogicalBridgeRequest {
-    // The object's `name` field is used to identify the object to be updated.
-    LogicalBridge logical_bridge = 1 [(google.api.field_behavior) = REQUIRED];
-    // The list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
-    // If set to true, and the object is not found, a new object will be created.
-    // In this situation, `update_mask` is ignored.
-    bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The object's `name` field is used to identify the object to be updated.
+  LogicalBridge logical_bridge = 1 [(google.api.field_behavior) = REQUIRED];
+  // The list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // If set to true, and the object is not found, a new object will be created.
+  // In this situation, `update_mask` is ignored.
+  bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Bridge Port network configuration and status
 message BridgePort {
-    option (google.api.resource) = {
-      type: "opi_api.network.evpn_gw.v1alpha1/BridgePort"
-      pattern: "bridgePorts/{bridge_port}"
-      singular: "bridgePort"
-      plural: "bridgePorts"
-    };
-    // The resource name of the Bridge Port.
-    // "name" is an opaque object handle that is not user settable.
-    // "name" will be returned with created object
-    // user can only set {resource}_id on the Create request object
-    // Format: bridge_ports/{bridge_port}
-    string name             = 1 [(google.api.field_behavior) = IDENTIFIER];
+  option (google.api.resource) = {
+    type: "opi_api.network.evpn_gw.v1alpha1/BridgePort"
+    pattern: "bridgePorts/{bridge_port}"
+    singular: "bridgePort"
+    plural: "bridgePorts"
+  };
+  // The resource name of the Bridge Port.
+  // "name" is an opaque object handle that is not user settable.
+  // "name" will be returned with created object
+  // user can only set {resource}_id on the Create request object
+  // Format: bridge_ports/{bridge_port}
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
-    // Bridge Port network configuration
-    BridgePortSpec spec     = 2 [(google.api.field_behavior) = REQUIRED];
-    // Bridge Port network status
-    BridgePortStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Bridge Port network configuration
+  BridgePortSpec spec = 2 [(google.api.field_behavior) = REQUIRED];
+  // Bridge Port network status
+  BridgePortStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Bridge Port network configuration
 message BridgePortSpec {
-    // Bridge Port's MAC address.
-    bytes mac_address               = 1 [(google.api.field_behavior) = REQUIRED];
-    // Type of Bridge Port
-    BridgePortType ptype            = 2 [(google.api.field_behavior) = REQUIRED];
-    // List of Logical Bridges this Bridge Port will attach.
-    // This will define the VLANs that will be enabled in this Bridge Port
-    repeated string logical_bridges = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Bridge Port's MAC address.
+  bytes mac_address = 1 [(google.api.field_behavior) = REQUIRED];
+  // Type of Bridge Port
+  BridgePortType ptype = 2 [(google.api.field_behavior) = REQUIRED];
+  // List of Logical Bridges this Bridge Port will attach.
+  // This will define the VLANs that will be enabled in this Bridge Port
+  repeated string logical_bridges = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // operational status of a Bridge Port
 message BridgePortStatus {
-    // operational status of a Bridge Port
-    BPOperStatus oper_status = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // status of the components
-    repeated Component components = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // operational status of a Bridge Port
+  BPOperStatus oper_status = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // status of the components
+  repeated Component components = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateBridgePortRequest structure
 message CreateBridgePortRequest {
-    // The ID to use for the bridge port, which will become the final component of
-    // the bridge port's resource name.
-    //
-    // This value should be 4-63 characters, and valid characters
-    // are /[a-z][0-9]-/.
-    // If this is not provided the system will auto-generate it.
-    string bridge_port_id     = 1 [(google.api.field_behavior) = OPTIONAL];
-    // The bridge port to create
-    BridgePort bridge_port    = 2 [(google.api.field_behavior) = REQUIRED];
+  // The ID to use for the bridge port, which will become the final component of
+  // the bridge port's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  // If this is not provided the system will auto-generate it.
+  string bridge_port_id = 1 [(google.api.field_behavior) = OPTIONAL];
+  // The bridge port to create
+  BridgePort bridge_port = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListBridgePortsRequest structure
 message ListBridgePortsRequest {
-    // page size of list request
-    int32 page_size   = 1 [(google.api.field_behavior) = OPTIONAL];
-    // page token of list request
-    string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // page size of list request
+  int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // page token of list request
+  string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListBridgePortsResponse structure
 message ListBridgePortsResponse {
-    // List of all the bridge ports
-    repeated BridgePort bridge_ports = 1;
-    // Next page token of list response
-    string next_page_token           = 2;
+  // List of all the bridge ports
+  repeated BridgePort bridge_ports = 1;
+  // Next page token of list response
+  string next_page_token = 2;
 }
 
 // GetBridgePortRequest structure
 message GetBridgePortRequest {
-    // The name of the bridge port to retrieve
-    // Format: bridgePorts/{bridge_port}
-    string name = 1 [
-      (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/BridgePort"
-    ];
+  // The name of the bridge port to retrieve
+  // Format: bridgePorts/{bridge_port}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/BridgePort"
+  ];
 }
 
 // DeleteBridgePortRequest structure
 message DeleteBridgePortRequest {
-    // The name of the bridge port to retrieve
-    // Format: bridgePorts/{bridge_port}
-    string name = 1 [
-      (google.api.field_behavior) = REQUIRED,
-      (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/BridgePort"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The name of the bridge port to retrieve
+  // Format: bridgePorts/{bridge_port}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/BridgePort"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // UpdateBridgePortRequest structure
 message UpdateBridgePortRequest {
-    // The object's `name` field is used to identify the object to be updated.
-    BridgePort bridge_port = 1  [(google.api.field_behavior) = REQUIRED];
-    // The list of fields to update.
-    google.protobuf.FieldMask update_mask = 2  [(google.api.field_behavior) = OPTIONAL];
-    // If set to true, and the object is not found, a new object will be created.
-    // In this situation, `update_mask` is ignored.
-    bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The object's `name` field is used to identify the object to be updated.
+  BridgePort bridge_port = 1 [(google.api.field_behavior) = REQUIRED];
+  // The list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // If set to true, and the object is not found, a new object will be created.
+  // In this situation, `update_mask` is ignored.
+  bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // LBOperStatus status reflects the operational status of a Logical Bridge
 enum LBOperStatus {
-    // unknown
-    LB_OPER_STATUS_UNSPECIFIED   = 0;
-    // Logical Bridge is up
-    LB_OPER_STATUS_UP            = 1;
-    // Logical Bridge is down
-    LB_OPER_STATUS_DOWN          = 2;
-    // Logical Bridge is to be deleted
-    LB_OPER_STATUS_TO_BE_DELETED = 3;
+  // unknown
+  LB_OPER_STATUS_UNSPECIFIED = 0;
+  // Logical Bridge is up
+  LB_OPER_STATUS_UP = 1;
+  // Logical Bridge is down
+  LB_OPER_STATUS_DOWN = 2;
+  // Logical Bridge is to be deleted
+  LB_OPER_STATUS_TO_BE_DELETED = 3;
 }
 
 // BPOperStatus status reflects the operational status of a Bridge Port
 enum BPOperStatus {
-    // unknown
-    BP_OPER_STATUS_UNSPECIFIED   = 0;
-    // Bridge Port is up
-    BP_OPER_STATUS_UP            = 1;
-    // Bridge Port is down
-    BP_OPER_STATUS_DOWN          = 2;
-    // Bridge Port is to be deleted
-    BP_OPER_STATUS_TO_BE_DELETED = 3;
+  // unknown
+  BP_OPER_STATUS_UNSPECIFIED = 0;
+  // Bridge Port is up
+  BP_OPER_STATUS_UP = 1;
+  // Bridge Port is down
+  BP_OPER_STATUS_DOWN = 2;
+  // Bridge Port is to be deleted
+  BP_OPER_STATUS_TO_BE_DELETED = 3;
 }
 
 // BridgePortType reflects the different types of a Bridge Port
 enum BridgePortType {
-    // "unknown" bridge port type
-    BRIDGE_PORT_TYPE_UNSPECIFIED = 0;
-    // "access" bridge port type 
-    BRIDGE_PORT_TYPE_ACCESS  = 1;
-    // "trunk" bridge port type
-    BRIDGE_PORT_TYPE_TRUNK   = 2;
+  // "unknown" bridge port type
+  BRIDGE_PORT_TYPE_UNSPECIFIED = 0;
+  // "access" bridge port type
+  BRIDGE_PORT_TYPE_ACCESS = 1;
+  // "trunk" bridge port type
+  BRIDGE_PORT_TYPE_TRUNK = 2;
 }

--- a/network/evpn-gw/l3_xpu_infra_mgr.proto
+++ b/network/evpn-gw/l3_xpu_infra_mgr.proto
@@ -15,345 +15,331 @@ syntax = "proto3";
 
 package opi_api.network.evpn_gw.v1alpha1;
 
-option go_package = "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go";
-option java_package = "opi_api.network.evpn_gw.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "L3XpuInfraMgrProto";
-
-import "network/opinetcommon/networktypes.proto";
-import "network/evpn-gw/component.proto";
-
 import "google/api/annotations.proto";
 import "google/api/client.proto";
-import "google/protobuf/empty.proto";
 import "google/api/field_behavior.proto";
-import "google/protobuf/field_mask.proto";
 import "google/api/resource.proto";
+import "google/protobuf/empty.proto";
+import "google/protobuf/field_mask.proto";
+import "network/evpn-gw/component.proto";
+import "network/opinetcommon/networktypes.proto";
+
+option go_package = "github.com/opiproject/opi-api/network/evpn-gw/v1alpha1/gen/go";
+option java_multiple_files = true;
+option java_outer_classname = "L3XpuInfraMgrProto";
+option java_package = "opi_api.network.evpn_gw.v1alpha1";
 
 // Management of Vrf Resources
 service VrfService {
-    // Create a Vrf
-    rpc CreateVrf(CreateVrfRequest) returns (Vrf){
-        option (google.api.http) = {
-          post: "/v1/vrfs"
-          body: "vrf"
-        };
-        option (google.api.method_signature) = "vrf,vrf_id";
-    }
-    // List Vrfs
-    rpc ListVrfs(ListVrfsRequest) returns (ListVrfsResponse){
-        option (google.api.http) = {
-          get: "/v1/vrfs"
-        };
-    }
-    // Retrieve a Vrf
-    rpc GetVrf(GetVrfRequest) returns (Vrf){
-        option (google.api.http) = {
-          get: "/v1/{name=vrfs/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Delete a Vrf
-    rpc DeleteVrf(DeleteVrfRequest) returns (google.protobuf.Empty){
-        option (google.api.http) = {
-          delete: "/v1/{name=vrfs/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Update a Vrf
-    rpc UpdateVrf(UpdateVrfRequest) returns (Vrf){
-        option (google.api.http) = {
-          patch: "/v1/{vrf.name=vrfs/*}"
-          body: "vrf"
-        };
-        option (google.api.method_signature) = "vrf,update_mask";
-    }
+  // Create a Vrf
+  rpc CreateVrf(CreateVrfRequest) returns (Vrf) {
+    option (google.api.http) = {
+      post: "/v1/vrfs"
+      body: "vrf"
+    };
+    option (google.api.method_signature) = "vrf,vrf_id";
+  }
+  // List Vrfs
+  rpc ListVrfs(ListVrfsRequest) returns (ListVrfsResponse) {
+    option (google.api.http) = {get: "/v1/vrfs"};
+  }
+  // Retrieve a Vrf
+  rpc GetVrf(GetVrfRequest) returns (Vrf) {
+    option (google.api.http) = {get: "/v1/{name=vrfs/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Delete a Vrf
+  rpc DeleteVrf(DeleteVrfRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=vrfs/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Update a Vrf
+  rpc UpdateVrf(UpdateVrfRequest) returns (Vrf) {
+    option (google.api.http) = {
+      patch: "/v1/{vrf.name=vrfs/*}"
+      body: "vrf"
+    };
+    option (google.api.method_signature) = "vrf,update_mask";
+  }
 }
 
 // Management of switch virtual interfaces (SVIs) binding LogicalBridges to VRFs.
 service SviService {
-    // Create a Svi
-    rpc CreateSvi(CreateSviRequest) returns (Svi){
-        option (google.api.http) = {
-          post: "/v1/svis"
-          body: "svi"
-        };
-        option (google.api.method_signature) = "svi,svi_id";
-    }
-    // List Svis
-    rpc ListSvis(ListSvisRequest) returns (ListSvisResponse){
-        option (google.api.http) = {
-          get: "/v1/svis"
-        };
-    }
-    // Retrieve a Svi
-    rpc GetSvi(GetSviRequest) returns (Svi){
-        option (google.api.http) = {
-          get: "/v1/{name=svis/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Delete a Svi
-    rpc DeleteSvi(DeleteSviRequest) returns (google.protobuf.Empty){
-        option (google.api.http) = {
-          delete: "/v1/{name=svis/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Update a Svi
-    rpc UpdateSvi(UpdateSviRequest) returns (Svi){
-        option (google.api.http) = {
-          patch: "/v1/{svi.name=svis/*}"
-          body: "svi"
-        };
-        option (google.api.method_signature) = "svi,update_mask";
-    }
+  // Create a Svi
+  rpc CreateSvi(CreateSviRequest) returns (Svi) {
+    option (google.api.http) = {
+      post: "/v1/svis"
+      body: "svi"
+    };
+    option (google.api.method_signature) = "svi,svi_id";
+  }
+  // List Svis
+  rpc ListSvis(ListSvisRequest) returns (ListSvisResponse) {
+    option (google.api.http) = {get: "/v1/svis"};
+  }
+  // Retrieve a Svi
+  rpc GetSvi(GetSviRequest) returns (Svi) {
+    option (google.api.http) = {get: "/v1/{name=svis/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Delete a Svi
+  rpc DeleteSvi(DeleteSviRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/v1/{name=svis/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Update a Svi
+  rpc UpdateSvi(UpdateSviRequest) returns (Svi) {
+    option (google.api.http) = {
+      patch: "/v1/{svi.name=svis/*}"
+      body: "svi"
+    };
+    option (google.api.method_signature) = "svi,update_mask";
+  }
 }
-
 
 // Vrf level network configuration
 message Vrf {
-    option (google.api.resource) = {
-      type: "opi_api.network.evpn_gw.v1alpha1/Vrf"
-      pattern: "vrfs/{vrf}"
-      singular: "vrf"
-      plural: "vrfs"
-    };
-    // The resource name of the Vrf.
-    // "name" is an opaque object handle that is not user settable.
-    // "name" will be returned with created object
-    // user can only set {resource}_id on the Create request object
-    // Format: vrfs/{vrf}
-    string name      = 1 [(google.api.field_behavior) = IDENTIFIER];
+  option (google.api.resource) = {
+    type: "opi_api.network.evpn_gw.v1alpha1/Vrf"
+    pattern: "vrfs/{vrf}"
+    singular: "vrf"
+    plural: "vrfs"
+  };
+  // The resource name of the Vrf.
+  // "name" is an opaque object handle that is not user settable.
+  // "name" will be returned with created object
+  // user can only set {resource}_id on the Create request object
+  // Format: vrfs/{vrf}
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
-    // Vrf's network configuration
-    VrfSpec spec     = 2 [(google.api.field_behavior) = REQUIRED];
-    // Vrf's network status
-    VrfStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Vrf's network configuration
+  VrfSpec spec = 2 [(google.api.field_behavior) = REQUIRED];
+  // Vrf's network status
+  VrfStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Vrf network configuration
 message VrfSpec {
-    // VXLAN VNI for L3 EVPN. Also used as EVPN route target
-    // (-- api-linter: core::0141::forbidden-types=disabled
-    //     aip.dev/not-precedent: vni cannot be negative number. --)
-    optional uint32 vni                                           = 1 [(google.api.field_behavior) = OPTIONAL];
-    // IPv4 or IPv6 loopback address prefix. Also serves as basis for RD in FRR
-    network.opinetcommon.v1alpha1.IPPrefix loopback_ip_prefix     = 2 [(google.api.field_behavior) = REQUIRED];
-    // IPv4 or IPv6 IP address prefix for the VXLAN TEP
-    network.opinetcommon.v1alpha1.IPPrefix vtep_ip_prefix         = 3 [(google.api.field_behavior) = OPTIONAL];
+  // VXLAN VNI for L3 EVPN. Also used as EVPN route target
+  // (-- api-linter: core::0141::forbidden-types=disabled
+  //     aip.dev/not-precedent: vni cannot be negative number. --)
+  optional uint32 vni = 1 [(google.api.field_behavior) = OPTIONAL];
+  // IPv4 or IPv6 loopback address prefix. Also serves as basis for RD in FRR
+  network.opinetcommon.v1alpha1.IPPrefix loopback_ip_prefix = 2 [(google.api.field_behavior) = REQUIRED];
+  // IPv4 or IPv6 IP address prefix for the VXLAN TEP
+  network.opinetcommon.v1alpha1.IPPrefix vtep_ip_prefix = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // operational status of a Vrf
 message VrfStatus {
-    // operational status of a Vrf
-    VRFOperStatus oper_status         = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // status of the components
-    repeated Component components     = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // operational status of a Vrf
+  VRFOperStatus oper_status = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // status of the components
+  repeated Component components = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateVrfRequest structure
 message CreateVrfRequest {
-    // The ID to use for the vrf, which will become the final component of
-    // the vrf's resource name.
-    //
-    // This value should be 4-63 characters, and valid characters
-    // are /[a-z][0-9]-/.
-    // If this is not provided the system will auto-generate it.
-    string vrf_id = 1 [(google.api.field_behavior) = OPTIONAL];
+  // The ID to use for the vrf, which will become the final component of
+  // the vrf's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  // If this is not provided the system will auto-generate it.
+  string vrf_id = 1 [(google.api.field_behavior) = OPTIONAL];
 
-    // The vrf to create
-    Vrf vrf       = 2 [(google.api.field_behavior) = REQUIRED];
+  // The vrf to create
+  Vrf vrf = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListVrfsRequest structure
 message ListVrfsRequest {
-    // page size of list request
-    int32 page_size   = 1 [(google.api.field_behavior) = OPTIONAL];
-    // page token of list request
-    string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // page size of list request
+  int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // page token of list request
+  string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListVrfsResponse structure
 message ListVrfsResponse {
-    // List of all the vrfs
-    repeated Vrf vrfs      = 1;
-    // Next page token of list response
-    string next_page_token = 2;
+  // List of all the vrfs
+  repeated Vrf vrfs = 1;
+  // Next page token of list response
+  string next_page_token = 2;
 }
 
 // GetVrfRequest structure
 message GetVrfRequest {
-    // The name of the vrf to retrieve
-    // Format: vrfs/{vrf}
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/Vrf"
-    ];
+  // The name of the vrf to retrieve
+  // Format: vrfs/{vrf}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/Vrf"
+  ];
 }
 
 // DeleteVrfRequest structure
 message DeleteVrfRequest {
-    // The name of the vrf to delete
-    // Format: vrfs/{vrf}
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/Vrf"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The name of the vrf to delete
+  // Format: vrfs/{vrf}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/Vrf"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // UpdateVrfRequest structure
 message UpdateVrfRequest {
-    // The object's `name` field is used to identify the object to be updated.
-    Vrf vrf = 1 [(google.api.field_behavior) = REQUIRED];
-    // The list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
-    // If set to true, and the object is not found, a new object will be created.
-    // In this situation, `update_mask` is ignored.
-    bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The object's `name` field is used to identify the object to be updated.
+  Vrf vrf = 1 [(google.api.field_behavior) = REQUIRED];
+  // The list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // If set to true, and the object is not found, a new object will be created.
+  // In this situation, `update_mask` is ignored.
+  bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Svi network configuration
 message Svi {
-    option (google.api.resource) = {
-      type: "opi_api.network.evpn_gw.v1alpha1/Svi"
-      pattern: "svis/{svi}"
-      singular: "svi"
-      plural: "svis"
-    };
-    // The resource name of the Svi.
-    // "name" is an opaque object handle that is not user settable.
-    // "name" will be returned with created object
-    // user can only set {resource}_id on the Create request object
-    // Format: svis/{svi}
-    string name      = 1 [(google.api.field_behavior) = IDENTIFIER];
+  option (google.api.resource) = {
+    type: "opi_api.network.evpn_gw.v1alpha1/Svi"
+    pattern: "svis/{svi}"
+    singular: "svi"
+    plural: "svis"
+  };
+  // The resource name of the Svi.
+  // "name" is an opaque object handle that is not user settable.
+  // "name" will be returned with created object
+  // user can only set {resource}_id on the Create request object
+  // Format: svis/{svi}
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
-    // Svi's network configuration
-    SviSpec spec     = 2 [(google.api.field_behavior) = REQUIRED];
-    // Svi's network status
-    SviStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Svi's network configuration
+  SviSpec spec = 2 [(google.api.field_behavior) = REQUIRED];
+  // Svi's network status
+  SviStatus status = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Svi's network configuration
 message SviSpec {
-    //Vrf name
-    // Format is `vrfs/{vrf}`
-    string vrf                                                   = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference) = {type: "opi_api.network.evpn_gw.v1alpha1/Vrf"}
-    ];
-    // Logical Bridge name
-    // Format is `logicalBridges/{logical_bridge}`
-    string logical_bridge                                        = 2 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference) = {type: "opi_api.network.evpn_gw.v1alpha1/LogicalBridge"}
-    ];
-    // Svi's MAC address.
-    bytes mac_address                                            = 3 [(google.api.field_behavior) = REQUIRED];
-    // The GW IP addresses assigned to the SVI
-    repeated network.opinetcommon.v1alpha1.IPPrefix gw_ip_prefix = 4 [(google.api.field_behavior) = REQUIRED];
-    // Set to true to enable BGP peering with Vrf on Svi
-    bool enable_bgp                                              = 5 [(google.api.field_behavior) = OPTIONAL];
-    // Conditional: The remote AS used by BGP speakers on LB (1-65535)
-    // (-- api-linter: core::0141::forbidden-types=disabled
-    //     aip.dev/not-precedent: remote_as cannot be negative number. --)
-    uint32 remote_as                                             = 6 [(google.api.field_behavior) = OPTIONAL];
+  //Vrf name
+  // Format is `vrfs/{vrf}`
+  string vrf = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "opi_api.network.evpn_gw.v1alpha1/Vrf"}
+  ];
+  // Logical Bridge name
+  // Format is `logicalBridges/{logical_bridge}`
+  string logical_bridge = 2 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference) = {type: "opi_api.network.evpn_gw.v1alpha1/LogicalBridge"}
+  ];
+  // Svi's MAC address.
+  bytes mac_address = 3 [(google.api.field_behavior) = REQUIRED];
+  // The GW IP addresses assigned to the SVI
+  repeated network.opinetcommon.v1alpha1.IPPrefix gw_ip_prefix = 4 [(google.api.field_behavior) = REQUIRED];
+  // Set to true to enable BGP peering with Vrf on Svi
+  bool enable_bgp = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Conditional: The remote AS used by BGP speakers on LB (1-65535)
+  // (-- api-linter: core::0141::forbidden-types=disabled
+  //     aip.dev/not-precedent: remote_as cannot be negative number. --)
+  uint32 remote_as = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // operational status of a Svi
 message SviStatus {
-    // operational status of a Svi
-    SVIOperStatus oper_status  = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // status of the components
-    repeated Component components = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // operational status of a Svi
+  SVIOperStatus oper_status = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // status of the components
+  repeated Component components = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // CreateSviRequest structure
 message CreateSviRequest {
-    // The ID to use for the svi, which will become the final component of
-    // the svi's resource name.
-    //
-    // This value should be 4-63 characters, and valid characters
-    // are /[a-z][0-9]-/.
-    // If this is not provided the system will auto-generate it.
-    string svi_id = 1 [(google.api.field_behavior) = OPTIONAL];
-    // The Svi to create
-    Svi svi       = 2 [(google.api.field_behavior) = REQUIRED];
+  // The ID to use for the svi, which will become the final component of
+  // the svi's resource name.
+  //
+  // This value should be 4-63 characters, and valid characters
+  // are /[a-z][0-9]-/.
+  // If this is not provided the system will auto-generate it.
+  string svi_id = 1 [(google.api.field_behavior) = OPTIONAL];
+  // The Svi to create
+  Svi svi = 2 [(google.api.field_behavior) = REQUIRED];
 }
 
 // ListSvisRequest structure
 message ListSvisRequest {
-    // page size of list request
-    int32 page_size   = 1  [(google.api.field_behavior) = OPTIONAL];
-    // page token of list request
-    string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
+  // page size of list request
+  int32 page_size = 1 [(google.api.field_behavior) = OPTIONAL];
+  // page token of list request
+  string page_token = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // ListSvisResponse structure
 message ListSvisResponse {
-    // List of all the svis
-    repeated Svi svis      = 1;
-    // Next page token of list response
-    string next_page_token = 2;
+  // List of all the svis
+  repeated Svi svis = 1;
+  // Next page token of list response
+  string next_page_token = 2;
 }
 
 // GetSviRequest structure
 message GetSviRequest {
-    // The name of the svi to retrieve
-    // Format: svis/{svi}
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/Svi"
-    ];
+  // The name of the svi to retrieve
+  // Format: svis/{svi}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/Svi"
+  ];
 }
 
 // DeleteSviRequest structure
 message DeleteSviRequest {
-    // The name of the svi to delete
-    // Format: svis/{svi}
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/Svi"
-    ];
-    // If set to true, and the resource is not found, the request will succeed
-    // but no action will be taken on the server
-    bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
+  // The name of the svi to delete
+  // Format: svis/{svi}
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.evpn_gw.v1alpha1/Svi"
+  ];
+  // If set to true, and the resource is not found, the request will succeed
+  // but no action will be taken on the server
+  bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // UpdateSviRequest structure
 message UpdateSviRequest {
-    // The object's `name` field is used to identify the object to be updated.
-    Svi svi = 1  [(google.api.field_behavior) = REQUIRED];
-    // The list of fields to update.
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
-    // If set to true, and the object is not found, a new object will be created.
-    // In this situation, `update_mask` is ignored.
-    bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The object's `name` field is used to identify the object to be updated.
+  Svi svi = 1 [(google.api.field_behavior) = REQUIRED];
+  // The list of fields to update.
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // If set to true, and the object is not found, a new object will be created.
+  // In this situation, `update_mask` is ignored.
+  bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // VRFOperStatus status reflects the operational status of a Vrf
 enum VRFOperStatus {
-    // unknown
-    VRF_OPER_STATUS_UNSPECIFIED   = 0;
-    // Vrf is up
-    VRF_OPER_STATUS_UP            = 1;
-    // Vrf is down
-    VRF_OPER_STATUS_DOWN          = 2;
-    // Vrf is to be deleted
-    VRF_OPER_STATUS_TO_BE_DELETED = 3;
+  // unknown
+  VRF_OPER_STATUS_UNSPECIFIED = 0;
+  // Vrf is up
+  VRF_OPER_STATUS_UP = 1;
+  // Vrf is down
+  VRF_OPER_STATUS_DOWN = 2;
+  // Vrf is to be deleted
+  VRF_OPER_STATUS_TO_BE_DELETED = 3;
 }
 
 // SVIOperStatus status reflects the operational status of a Svi
 enum SVIOperStatus {
-    // unknown
-    SVI_OPER_STATUS_UNSPECIFIED   = 0;
-    // Svi is up
-    SVI_OPER_STATUS_UP            = 1;
-    // Svi is down
-    SVI_OPER_STATUS_DOWN          = 2;
-    // Svi is to be deleted
-    SVI_OPER_STATUS_TO_BE_DELETED = 3;
+  // unknown
+  SVI_OPER_STATUS_UNSPECIFIED = 0;
+  // Svi is up
+  SVI_OPER_STATUS_UP = 1;
+  // Svi is down
+  SVI_OPER_STATUS_DOWN = 2;
+  // Svi is to be deleted
+  SVI_OPER_STATUS_TO_BE_DELETED = 3;
 }

--- a/network/k8s/k8s.proto
+++ b/network/k8s/k8s.proto
@@ -4,8 +4,7 @@
 syntax = "proto3";
 package opi_api.network.k8s.v1alpha1;
 
-option java_package = "opi_api.network.k8s.v1alpha1";
+option go_package = "github.com/opiproject/opi-api/network/k8s/v1alpha1/gen/go";
 option java_multiple_files = true;
 option java_outer_classname = "K8sProto";
-
-option go_package = "github.com/opiproject/opi-api/network/k8s/v1alpha1/gen/go";
+option java_package = "opi_api.network.k8s.v1alpha1";

--- a/network/opinetcommon/networkethernet.proto
+++ b/network/opinetcommon/networkethernet.proto
@@ -2,216 +2,214 @@
 // Copyright (c) 2024 Dell Inc, or its subsidiaries.
 //
 // Derived from the OpenConfig interfaces model github.com/openconfig/public/release/models/interfaces
-// 
+//
 // (-- api-linter: core::0141::forbidden-types=disabled
 //     aip.dev/not-precedent: counters, mtu, index must be uint and not int. --)
 syntax = "proto3";
 
 package opi_api.network.opinetcommon.v1alpha1;
 
-option java_package = "opi_api.network.opinetcommon.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "NetworkEthernetProto";
-
-option go_package = "github.com/opiproject/opi-api/network/opinetcommon/v1alpha1/gen/go";
-
+import "google/api/field_behavior.proto";
 import "network/opinetcommon/networkvlan.proto";
 
-import "google/api/field_behavior.proto";
+option go_package = "github.com/opiproject/opi-api/network/opinetcommon/v1alpha1/gen/go";
+option java_multiple_files = true;
+option java_outer_classname = "NetworkEthernetProto";
+option java_package = "opi_api.network.opinetcommon.v1alpha1";
 
 // Ethernet Configuration
 message EthernetConfig {
-    // MAC address to assign to the Ethernet Interface if not assigned
-    string mac_address = 1 [(google.api.field_behavior) = OPTIONAL];
-    // Set to TRUE to request autonegotiate the transmission parameters 
-    // with the peer interface
-    bool auto_negotiate = 2 [(google.api.field_behavior) = OPTIONAL];
-    // Used when full autonegotiation is not desired by setting to TRUE
-    // and setting auto_negotiate to FALSE.  It is ignored when auto-negotiate
-    // is set to TRUE.
-    bool standalone_link_training = 3 [(google.api.field_behavior) = OPTIONAL];
-    // Optionally sets the duplex mode that is advertised to the peer interface
-    EthDuplexMode duplex_mode = 4 [(google.api.field_behavior) = OPTIONAL];
-    // Optionally sets the port speed that is advertised to the peer interface
-    EthPortSpeed port_speed = 5 [(google.api.field_behavior) = OPTIONAL];
-    // Override for the negotiated flow control on the interface
-    bool enable_flow_control = 6 [(google.api.field_behavior) = OPTIONAL];
-    // FEC applied to the physical channel of the interface
-    EthFecMode fec_mode = 7 [(google.api.field_behavior) = OPTIONAL];
+  // MAC address to assign to the Ethernet Interface if not assigned
+  string mac_address = 1 [(google.api.field_behavior) = OPTIONAL];
+  // Set to TRUE to request autonegotiate the transmission parameters
+  // with the peer interface
+  bool auto_negotiate = 2 [(google.api.field_behavior) = OPTIONAL];
+  // Used when full autonegotiation is not desired by setting to TRUE
+  // and setting auto_negotiate to FALSE.  It is ignored when auto-negotiate
+  // is set to TRUE.
+  bool standalone_link_training = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Optionally sets the duplex mode that is advertised to the peer interface
+  EthDuplexMode duplex_mode = 4 [(google.api.field_behavior) = OPTIONAL];
+  // Optionally sets the port speed that is advertised to the peer interface
+  EthPortSpeed port_speed = 5 [(google.api.field_behavior) = OPTIONAL];
+  // Override for the negotiated flow control on the interface
+  bool enable_flow_control = 6 [(google.api.field_behavior) = OPTIONAL];
+  // FEC applied to the physical channel of the interface
+  EthFecMode fec_mode = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Ethernet receive frame distribution counters
 message EthernetInDistribution {
-    // Receive counter for 64 byte frames
-    uint64 rx_frames_octets64 = 1;
-    // Receive counter for 65 to 127 byte frames
-    uint64 rx_frames_octets65_to127 = 2;
-    // Receive counter for 128 to 255 byte frames
-    uint64 rx_frames_octets128_to255 = 3;
-    // receive counter for 256 to 511 byte frames
-    uint64 rx_frames_octets256_to511 = 4;
-    // receive counter for 512 to 1023 byte frames
-    uint64 rx_frames_octets512_to1023 = 5;
-    // receive counter for 1024 to 1518 byte frames
-    uint64 rx_frames_octets1024_to1518 = 6;
+  // Receive counter for 64 byte frames
+  uint64 rx_frames_octets64 = 1;
+  // Receive counter for 65 to 127 byte frames
+  uint64 rx_frames_octets65_to127 = 2;
+  // Receive counter for 128 to 255 byte frames
+  uint64 rx_frames_octets128_to255 = 3;
+  // receive counter for 256 to 511 byte frames
+  uint64 rx_frames_octets256_to511 = 4;
+  // receive counter for 512 to 1023 byte frames
+  uint64 rx_frames_octets512_to1023 = 5;
+  // receive counter for 1024 to 1518 byte frames
+  uint64 rx_frames_octets1024_to1518 = 6;
 }
 
 // Ethernet Interface Counters
 message EthernetCounters {
-    // received mac control frame counter
-    uint64 rx_mac_control_frames = 1;
-    // received mac pause frame counter
-    uint64 rx_mac_pause_frames = 2;
-    // frames received that were oversized on the interface
-    // (larger then 1518 octets)
-    uint64 rx_oversize_frames = 3;
-    // frames received that were undersized on the interface
-    // (smaller then 64 octets)
-    uint64 rx_undersize_frames = 4;
-    // Number of jabber frames received on the interface.
-    // Jabber frames are typically defined as oversize frames which also
-    // have a bad CRC
-    uint64 rx_jabber_frames = 5;
-    // The total number of frames received that were less than 64 octets
-    // in length (excluding framing bits but including FCS octets)
-    // and had either a bad Frame Check Sequence (FCS) with an integral
-    // number of octets (FCS Error) or a bad FCS with a non-integral number
-    // of octets (Alignment Error)
-    uint64 rx_fragment_frames = 6;
-    // Number of 802.1q tagged frames received on the interface
-    uint64 rx_ieee8021q_frames = 7;
-    // The total number of frames received that had FCS errors
-    uint64 rx_crc_errors = 8;
-    // The number of received errored blocks
-    uint64 rx_block_errors = 9;
-    // The number of received errored frames due to a carrier issue
-    uint64 rx_carrier_errors = 10;
-    // The number of received errored frames due to interrupted transmission
-    // issue
-    uint64 rx_interrupted_tx = 11;
-    // The number of received errored frames due to late collision issue
-    uint64 rx_late_collision = 12;
-    // The number of received errored frames due to MAC errors received
-    uint64 rx_mac_errors_rx = 13;
-    // The number of received errored frames due to single collision issue
-    uint64 rx_single_collision = 14;
-    // The number of received errored frames due to symbol error
-    uint64 rx_symbol_error = 15;
-    // The total number frames received that are well-formed but dropped due
-    // to exceeding the maximum frame size on the interface
-    uint64 rx_maxsize_exceeded = 16;
-    // MAC layer control frames sent on the interface
-    uint64 out_mac_control_frames = 17;
-    // MAC layer PAUSE frames sent on the interface
-    uint64 out_mac_pause_frames = 18;
-    // Number of 802.1q tagged frames sent on the interface
-    uint64 out_ieee8021q_frames = 19;
-    // The number of sent errored frames due to MAC errors transmitted
-    uint64 out_mac_errors_tx = 20;
-    // Receive Frame Distribution counters
-    EthernetInDistribution eth_rx_distribution = 21;
+  // received mac control frame counter
+  uint64 rx_mac_control_frames = 1;
+  // received mac pause frame counter
+  uint64 rx_mac_pause_frames = 2;
+  // frames received that were oversized on the interface
+  // (larger then 1518 octets)
+  uint64 rx_oversize_frames = 3;
+  // frames received that were undersized on the interface
+  // (smaller then 64 octets)
+  uint64 rx_undersize_frames = 4;
+  // Number of jabber frames received on the interface.
+  // Jabber frames are typically defined as oversize frames which also
+  // have a bad CRC
+  uint64 rx_jabber_frames = 5;
+  // The total number of frames received that were less than 64 octets
+  // in length (excluding framing bits but including FCS octets)
+  // and had either a bad Frame Check Sequence (FCS) with an integral
+  // number of octets (FCS Error) or a bad FCS with a non-integral number
+  // of octets (Alignment Error)
+  uint64 rx_fragment_frames = 6;
+  // Number of 802.1q tagged frames received on the interface
+  uint64 rx_ieee8021q_frames = 7;
+  // The total number of frames received that had FCS errors
+  uint64 rx_crc_errors = 8;
+  // The number of received errored blocks
+  uint64 rx_block_errors = 9;
+  // The number of received errored frames due to a carrier issue
+  uint64 rx_carrier_errors = 10;
+  // The number of received errored frames due to interrupted transmission
+  // issue
+  uint64 rx_interrupted_tx = 11;
+  // The number of received errored frames due to late collision issue
+  uint64 rx_late_collision = 12;
+  // The number of received errored frames due to MAC errors received
+  uint64 rx_mac_errors_rx = 13;
+  // The number of received errored frames due to single collision issue
+  uint64 rx_single_collision = 14;
+  // The number of received errored frames due to symbol error
+  uint64 rx_symbol_error = 15;
+  // The total number frames received that are well-formed but dropped due
+  // to exceeding the maximum frame size on the interface
+  uint64 rx_maxsize_exceeded = 16;
+  // MAC layer control frames sent on the interface
+  uint64 out_mac_control_frames = 17;
+  // MAC layer PAUSE frames sent on the interface
+  uint64 out_mac_pause_frames = 18;
+  // Number of 802.1q tagged frames sent on the interface
+  uint64 out_ieee8021q_frames = 19;
+  // The number of sent errored frames due to MAC errors transmitted
+  uint64 out_mac_errors_tx = 20;
+  // Receive Frame Distribution counters
+  EthernetInDistribution eth_rx_distribution = 21;
 }
 
 // Ethernet interface state settings
 message EthernetState {
-    // MAC address to assign to the Ethernet Interface if not assigned or
-    // being overridden.
-    string mac_address = 1;
-    // Set to TRUE to request autonegotiate the transmission parameters 
-    // with the peer interface
-    bool auto_negotiate = 2;
-    // Used when full autonegotiation is not desired by setting to TRUE
-    // and setting auto_negotiate to FALSE.  It is ignored when auto-negotiate
-    // is set to TRUE.
-    bool standalone_link_training = 3;
-    // The duplex mode that is negotiated or set interface
-    EthDuplexMode duplex_mode = 4;
-    // The port speed that is negotiated or set for the interface
-    EthPortSpeed port_speed = 5;
-    // Override for the negotiated flow control on the interface
-    bool enable_flow_control = 6;
-    // FEC applied to the physical channel of the interface
-    EthFecMode fec_mode = 7;
-    // Hardware MAC address defined for the interface
-    string hw_mac_address = 8;
-    // Negotiated Duplex mode for the interface
-    EthDuplexMode negotiated_duplex_mode = 9;
-    // Negotiated Port Speed for the interface
-    EthPortSpeed negotiated_port_speed = 10;
-    // Ethernet port counters
-    EthernetCounters counters = 11;
+  // MAC address to assign to the Ethernet Interface if not assigned or
+  // being overridden.
+  string mac_address = 1;
+  // Set to TRUE to request autonegotiate the transmission parameters
+  // with the peer interface
+  bool auto_negotiate = 2;
+  // Used when full autonegotiation is not desired by setting to TRUE
+  // and setting auto_negotiate to FALSE.  It is ignored when auto-negotiate
+  // is set to TRUE.
+  bool standalone_link_training = 3;
+  // The duplex mode that is negotiated or set interface
+  EthDuplexMode duplex_mode = 4;
+  // The port speed that is negotiated or set for the interface
+  EthPortSpeed port_speed = 5;
+  // Override for the negotiated flow control on the interface
+  bool enable_flow_control = 6;
+  // FEC applied to the physical channel of the interface
+  EthFecMode fec_mode = 7;
+  // Hardware MAC address defined for the interface
+  string hw_mac_address = 8;
+  // Negotiated Duplex mode for the interface
+  EthDuplexMode negotiated_duplex_mode = 9;
+  // Negotiated Port Speed for the interface
+  EthPortSpeed negotiated_port_speed = 10;
+  // Ethernet port counters
+  EthernetCounters counters = 11;
 }
 
 // Ethernet Interface
 message EthernetInterface {
-    // Ethernet Interface Configuration settings
-    EthernetConfig config = 1;
-    // Ethernet Interface State information
-    EthernetState state = 2;
-    // Switched VLAN Interface configuration for interface
-    VlanSwitchedIf switched_vlan = 3;
+  // Ethernet Interface Configuration settings
+  EthernetConfig config = 1;
+  // Ethernet Interface State information
+  EthernetState state = 2;
+  // Switched VLAN Interface configuration for interface
+  VlanSwitchedIf switched_vlan = 3;
 }
 
 // Ethernet Duplex Mode Definitions
 enum EthDuplexMode {
-    // Unspecified - interface will negotiate duplex speed directly
-    ETH_DUPLEX_MODE_UNSPECIFIED = 0;
-    // Specify Full Duplex mode in autonegotiation
-    ETH_DUPLEX_MODE_FULL = 1;
-    // Specify Half Duplex mode in autonegotiation
-    ETH_DUPLEX_MODE_HALF = 2;
+  // Unspecified - interface will negotiate duplex speed directly
+  ETH_DUPLEX_MODE_UNSPECIFIED = 0;
+  // Specify Full Duplex mode in autonegotiation
+  ETH_DUPLEX_MODE_FULL = 1;
+  // Specify Half Duplex mode in autonegotiation
+  ETH_DUPLEX_MODE_HALF = 2;
 }
 
 // Ethernet Port Speed Definitions
 enum EthPortSpeed {
-    // Unspecified - interface will negotiate port speed with the peer interface
-    ETH_PORT_SPEED_UNSPECIFIED = 0;
-    // 10M port speed
-    ETH_PORT_SPEED_10M = 1;
-    // 100M port speed
-    ETH_PORT_SPEED_100M = 2;
-    // 1G port speed
-    ETH_PORT_SPEED_1G = 3;
-    // 2.5G port speed
-    ETH_PORT_SPEED_2500M = 4;
-    // 5G port speed
-    ETH_PORT_SPEED_5G = 5;
-    // 10G port speed
-    ETH_PORT_SPEED_10G = 6;
-    // 25G port speed
-    ETH_PORT_SPEED_25G = 7;
-    // 40G port speed
-    ETH_PORT_SPEED_40G = 8;
-    // 50G port speed
-    ETH_PORT_SPEED_50G = 9;
-    // 100G port speed
-    ETH_PORT_SPEED_100G = 10;
-    // 200G port speed
-    ETH_PORT_SPEED_200G = 11;
-    // 400G port speed
-    ETH_PORT_SPEED_400G = 12;
-    // 600G port speed
-    ETH_PORT_SPEED_600G = 13;
-    // 800G port speed
-    ETH_PORT_SPEED_800G = 14;
-    // Interface speed is unknown.  Systems may report
-    // speed UNKNOWN when an interface is down or unpopuplated
-    ETH_PORT_SPEED_UNKNOWN = 15;
+  // Unspecified - interface will negotiate port speed with the peer interface
+  ETH_PORT_SPEED_UNSPECIFIED = 0;
+  // 10M port speed
+  ETH_PORT_SPEED_10M = 1;
+  // 100M port speed
+  ETH_PORT_SPEED_100M = 2;
+  // 1G port speed
+  ETH_PORT_SPEED_1G = 3;
+  // 2.5G port speed
+  ETH_PORT_SPEED_2500M = 4;
+  // 5G port speed
+  ETH_PORT_SPEED_5G = 5;
+  // 10G port speed
+  ETH_PORT_SPEED_10G = 6;
+  // 25G port speed
+  ETH_PORT_SPEED_25G = 7;
+  // 40G port speed
+  ETH_PORT_SPEED_40G = 8;
+  // 50G port speed
+  ETH_PORT_SPEED_50G = 9;
+  // 100G port speed
+  ETH_PORT_SPEED_100G = 10;
+  // 200G port speed
+  ETH_PORT_SPEED_200G = 11;
+  // 400G port speed
+  ETH_PORT_SPEED_400G = 12;
+  // 600G port speed
+  ETH_PORT_SPEED_600G = 13;
+  // 800G port speed
+  ETH_PORT_SPEED_800G = 14;
+  // Interface speed is unknown.  Systems may report
+  // speed UNKNOWN when an interface is down or unpopuplated
+  ETH_PORT_SPEED_UNKNOWN = 15;
 }
 
 // Ethernet Forward Error Correction Mode Definitions
 enum EthFecMode {
-    // Unspecified
-    ETH_FEC_MODE_UNSPECIFIED = 0;
-    // Firecode for NRZ channels with less then 100G
-    ETH_FEC_MODE_FC = 1;
-    // RS528 is used for channels with NRZ modulation. This FEC is designed to
-    // comply with IEEE 802.3, Clause 91.
-    ETH_FEC_MODE_RS528 = 2;
-    // RS544 is used for channels with PAM4 modulation
-    ETH_FEC_MODE_RS544 = 3;
-    // RS544-2x-interleave is used for channels with PAM4 modulation
-    ETH_FEC_MODE_RS544_2X_INTERLEAVE = 4;
-    // FEC is administratively disabled
-    ETH_FEC_MODE_DISABLED = 5;
+  // Unspecified
+  ETH_FEC_MODE_UNSPECIFIED = 0;
+  // Firecode for NRZ channels with less then 100G
+  ETH_FEC_MODE_FC = 1;
+  // RS528 is used for channels with NRZ modulation. This FEC is designed to
+  // comply with IEEE 802.3, Clause 91.
+  ETH_FEC_MODE_RS528 = 2;
+  // RS544 is used for channels with PAM4 modulation
+  ETH_FEC_MODE_RS544 = 3;
+  // RS544-2x-interleave is used for channels with PAM4 modulation
+  ETH_FEC_MODE_RS544_2X_INTERLEAVE = 4;
+  // FEC is administratively disabled
+  ETH_FEC_MODE_DISABLED = 5;
 }

--- a/network/opinetcommon/networkinterfaces.proto
+++ b/network/opinetcommon/networkinterfaces.proto
@@ -9,297 +9,291 @@ syntax = "proto3";
 
 package opi_api.network.opinetcommon.v1alpha1;
 
-option java_package = "opi_api.network.opinetcommon.v1alpha1";
-option java_multiple_files = true;
-option java_outer_classname = "NetworkInterfacesProto";
-
-option go_package = "github.com/opiproject/opi-api/network/opinetcommon/v1alpha1/gen/go";
-
+import "google/api/annotations.proto";
+import "google/api/client.proto";
+import "google/api/field_behavior.proto";
+import "google/api/resource.proto";
+import "google/protobuf/field_mask.proto";
+import "network/opinetcommon/networkethernet.proto";
 import "network/opinetcommon/networktypes.proto";
 import "network/opinetcommon/networkvlan.proto";
-import "network/opinetcommon/networkethernet.proto";
 
-import "google/api/client.proto";
-import "google/api/resource.proto";
-import "google/api/annotations.proto";
-import "google/api/field_behavior.proto";
-import "google/protobuf/field_mask.proto";
+option go_package = "github.com/opiproject/opi-api/network/opinetcommon/v1alpha1/gen/go";
+option java_multiple_files = true;
+option java_outer_classname = "NetworkInterfacesProto";
+option java_package = "opi_api.network.opinetcommon.v1alpha1";
 
 // Service functions for Network Interface exported by the server
 service NetInterfaceService {
-    // Retrieves the interface information for a given interface
-    rpc GetNetInterface (GetNetInterfaceRequest) returns (NetInterface) {
-        option (google.api.http) = {
-            get: "/v1/{name=interfaces/*/interface/*}"
-        };
-        option (google.api.method_signature) = "name";
-    }
-    // Retrieves the set of interfaces on the device
-    rpc ListNetInterfaces (ListNetInterfacesRequest) returns (ListNetInterfacesResponse) {
-        option (google.api.http) = {
-            get: "/v1/{parent=interfaces}"
-        };
-        option (google.api.method_signature) = "parent";
-    }
-    // A method for setting or changing configuration of an interface
-    rpc UpdateNetInterface (UpdateNetInterfaceRequest) returns (NetInterface) {
-        option (google.api.http) = {
-            patch: "/v1/{net_interface.name=interfaces/*/interface/*}"
-            body: "net_interface"
-        };
-        option (google.api.method_signature) = "net_interface,update_mask";
-    }
-    // (-- TODO Add Create network interface for adding additional virtual interfaces --)
-    // (-- TODO Add Delete network interface for removing virtual interfaces --)
+  // Retrieves the interface information for a given interface
+  rpc GetNetInterface(GetNetInterfaceRequest) returns (NetInterface) {
+    option (google.api.http) = {get: "/v1/{name=interfaces/*/interface/*}"};
+    option (google.api.method_signature) = "name";
+  }
+  // Retrieves the set of interfaces on the device
+  rpc ListNetInterfaces(ListNetInterfacesRequest) returns (ListNetInterfacesResponse) {
+    option (google.api.http) = {get: "/v1/{parent=interfaces}"};
+    option (google.api.method_signature) = "parent";
+  }
+  // A method for setting or changing configuration of an interface
+  rpc UpdateNetInterface(UpdateNetInterfaceRequest) returns (NetInterface) {
+    option (google.api.http) = {
+      patch: "/v1/{net_interface.name=interfaces/*/interface/*}"
+      body: "net_interface"
+    };
+    option (google.api.method_signature) = "net_interface,update_mask";
+  }
+  // (-- TODO Add Create network interface for adding additional virtual interfaces --)
+  // (-- TODO Add Delete network interface for removing virtual interfaces --)
 }
 
 // Interface config
 // (-- api-linter: core::0123::resource-annotation=disabled
 //     aip.dev/not-precedent: the name field is an opaque object --)
 message NetInterfaceConfig {
-    // Name of the interface.  This is the opaque object
-    // used for designating the created interface.
-    string name = 1 [(google.api.field_behavior) = REQUIRED];
-    // Type of interface - Ethernet and others
-    InterfaceType type = 2 [(google.api.field_behavior) = REQUIRED];
-    // MTU for the interface that can be configured
-    uint32 mtu = 3 [(google.api.field_behavior) = REQUIRED];
-    // Setting the loopback mode of the interface
-    bool loopback_mode = 4 [(google.api.field_behavior) = REQUIRED];
-    // Description of the interface and usage
-    string description = 5 [(google.api.field_behavior) = REQUIRED];
-    // Setting for enabling/disabling the interface
-    bool enabled = 6 [(google.api.field_behavior) = REQUIRED];
-    // VLAN Tag Protocol Identifier (TPID)
-    TpidTypes tpid = 7 [(google.api.field_behavior) = OPTIONAL];
+  // Name of the interface.  This is the opaque object
+  // used for designating the created interface.
+  string name = 1 [(google.api.field_behavior) = REQUIRED];
+  // Type of interface - Ethernet and others
+  InterfaceType type = 2 [(google.api.field_behavior) = REQUIRED];
+  // MTU for the interface that can be configured
+  uint32 mtu = 3 [(google.api.field_behavior) = REQUIRED];
+  // Setting the loopback mode of the interface
+  bool loopback_mode = 4 [(google.api.field_behavior) = REQUIRED];
+  // Description of the interface and usage
+  string description = 5 [(google.api.field_behavior) = REQUIRED];
+  // Setting for enabling/disabling the interface
+  bool enabled = 6 [(google.api.field_behavior) = REQUIRED];
+  // VLAN Tag Protocol Identifier (TPID)
+  TpidTypes tpid = 7 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Statistics Counters for the interface - ro
 message NetInterfaceCounters {
-    // Received Octet counter
-    uint64 rx_octets = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Received Packet counter
-    uint64 rx_packets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Unicast packets received counter
-    uint64 rx_unicast_pkts = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Broadcast packets received counter
-    uint64 rx_broadcast_pkts = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // multicast packets received counter
-    uint64 rx_multicast_pkts = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // discarded received packets counter
-    uint64 rx_discards = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Receive error counter
-    uint64 rx_errors = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Unknown received protocol counter
-    uint64 rx_unknown_protos = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Received FCS error counter
-    uint64 rx_fcs_errors = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Transmit octet counter
-    uint64 out_octets = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Transmit packet counter
-    uint64 out_packets = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Unicast packet transmit counter
-    uint64 out_unicast_pkts = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Broadcast packet transmit counter
-    uint64 out_broadcast_pkts = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Multicast packet transmit counter
-    uint64 out_multicast_pkts = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Discarded transmit packet counter
-    uint64 out_discards = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Transmit error counter
-    uint64 out_errors = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Carrier transition count
-    uint64 carrier_transitions = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Timestamp of the last time the interface counters were cleared
-    uint64 last_clear = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Received Octet counter
+  uint64 rx_octets = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Received Packet counter
+  uint64 rx_packets = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Unicast packets received counter
+  uint64 rx_unicast_pkts = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Broadcast packets received counter
+  uint64 rx_broadcast_pkts = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // multicast packets received counter
+  uint64 rx_multicast_pkts = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // discarded received packets counter
+  uint64 rx_discards = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Receive error counter
+  uint64 rx_errors = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Unknown received protocol counter
+  uint64 rx_unknown_protos = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Received FCS error counter
+  uint64 rx_fcs_errors = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Transmit octet counter
+  uint64 out_octets = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Transmit packet counter
+  uint64 out_packets = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Unicast packet transmit counter
+  uint64 out_unicast_pkts = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Broadcast packet transmit counter
+  uint64 out_broadcast_pkts = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Multicast packet transmit counter
+  uint64 out_multicast_pkts = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Discarded transmit packet counter
+  uint64 out_discards = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Transmit error counter
+  uint64 out_errors = 16 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Carrier transition count
+  uint64 carrier_transitions = 17 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Timestamp of the last time the interface counters were cleared
+  uint64 last_clear = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 // Interface State information - ro
 // (-- api-linter: core::0123::resource-annotation=disabled
 //     aip.dev/not-precedent: the name field is an opaque object --)
 message NetInterfaceState {
-    // Name of the interface.  This is the opaque object
-    // used for designating the created interface.
-    string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Interface type indicator
-    InterfaceType type = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Configured MTU size
-    uint32 mtu = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Configured Loopback mode
-    bool loopback_mode = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Interface description
-    string description = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Interface enabled indicator
-    bool enabled = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Interface Index
-    uint32 ifindex = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Admin State
-    network.opinetcommon.v1alpha1.AdminState admin_state = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Operational State
-    OperState oper_state = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Last Change
-    uint64 last_change = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Logical interface - when set to true indicates a logical interface with
-    // no associated physical port or channel
-    bool logical = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Management interface - when set to true indicates a dedicated management
-    // interface that is independent of the dataplane interfaces such as an out
-    // of band management network
-    bool management = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // CPU interface - when set to true the interface is for traffic handled by
-    // the system CPU or control plane
-    bool cpu = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // Interface Statistics Counters
-    NetInterfaceCounters counters = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
-    // VLAN Tag Protocol Identifier
-    TpidTypes tpid = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Name of the interface.  This is the opaque object
+  // used for designating the created interface.
+  string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Interface type indicator
+  InterfaceType type = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Configured MTU size
+  uint32 mtu = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Configured Loopback mode
+  bool loopback_mode = 4 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Interface description
+  string description = 5 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Interface enabled indicator
+  bool enabled = 6 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Interface Index
+  uint32 ifindex = 7 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Admin State
+  network.opinetcommon.v1alpha1.AdminState admin_state = 8 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Operational State
+  OperState oper_state = 9 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Last Change
+  uint64 last_change = 10 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Logical interface - when set to true indicates a logical interface with
+  // no associated physical port or channel
+  bool logical = 11 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Management interface - when set to true indicates a dedicated management
+  // interface that is independent of the dataplane interfaces such as an out
+  // of band management network
+  bool management = 12 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // CPU interface - when set to true the interface is for traffic handled by
+  // the system CPU or control plane
+  bool cpu = 13 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Interface Statistics Counters
+  NetInterfaceCounters counters = 14 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // VLAN Tag Protocol Identifier
+  TpidTypes tpid = 15 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
 
 //Interface - physical or virtual interface reported
 // (-- api-linter: core::0123::resource-annotation=disabled
 //     aip.dev/not-precedent: the name field is an opaque object --)
 message NetInterface {
-    option (google.api.resource) = {
-        type: "opi_api.network.opinetcommon.v1alpha1/NetInterface"
-        pattern: "netInterface/{interface}"
-        singular: "netInterface"
-        plural: "netInterfaces"
-    };
-    // Name of the interface.  This is an opaque object that is not
-    // user settable.  It is returned by the created object
-    string name = 1 [(google.api.field_behavior) = IDENTIFIER];
-    // Configuration settings - rw
-    NetInterfaceConfig config = 2 [(google.api.field_behavior) = REQUIRED];
-    // Interface State and Statistics - ro
-    NetInterfaceState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+  option (google.api.resource) = {
+    type: "opi_api.network.opinetcommon.v1alpha1/NetInterface"
+    pattern: "netInterface/{interface}"
+    singular: "netInterface"
+    plural: "netInterfaces"
+  };
+  // Name of the interface.  This is an opaque object that is not
+  // user settable.  It is returned by the created object
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
+  // Configuration settings - rw
+  NetInterfaceConfig config = 2 [(google.api.field_behavior) = REQUIRED];
+  // Interface State and Statistics - ro
+  NetInterfaceState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
 
-    // Hold Time Settings
-    message HoldTime {
-        // Hold Time Config - rw
-        message HoldConfig {
-            // Hold time up
-            uint32 up = 1 [(google.api.field_behavior) = OPTIONAL];
-            // Hold time down
-            uint32 down = 2 [(google.api.field_behavior) = OPTIONAL];
-        }
-        // Hold Time Config
-        HoldConfig hold_config = 1 [(google.api.field_behavior) = OPTIONAL];
-
-        // Hold State Settings - ro
-        message HoldState {
-            // Hold state up
-            uint32 up = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
-            // Hold state down
-            uint32 down = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
-        }
-        // Hold State Settings
-        HoldState hold_state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  // Hold Time Settings
+  message HoldTime {
+    // Hold Time Config - rw
+    message HoldConfig {
+      // Hold time up
+      uint32 up = 1 [(google.api.field_behavior) = OPTIONAL];
+      // Hold time down
+      uint32 down = 2 [(google.api.field_behavior) = OPTIONAL];
     }
-    // Hold Time Settings
-    HoldTime holdtime = 4 [(google.api.field_behavior) = OPTIONAL];
+    // Hold Time Config
+    HoldConfig hold_config = 1 [(google.api.field_behavior) = OPTIONAL];
 
-    // Subinterfaces settings - VLAN, etc.
-    message Subinterfaces {
-        // Subinterface settings
-        message Subinterface {
-            // Subinterface index
-            int64 index = 1 [(google.api.field_behavior) = OPTIONAL];
-
-            // Subinterface configuration
-            message SubifConfig {
-                // Subinterface Index
-                uint64 index = 1 [(google.api.field_behavior) = OPTIONAL];
-                // Subinterface description
-                string description = 2 [(google.api.field_behavior) = OPTIONAL];
-                // Subinterface enabled
-                bool enabled = 3 [(google.api.field_behavior) = OPTIONAL];
-            }
-            // Subinterface Configuration
-            SubifConfig subif_config = 2 [(google.api.field_behavior) = OPTIONAL];
-
-            // Subinterface State and Statistics
-            NetInterfaceState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
-
-            // Subinterface VLAN
-            VlanIf vlan = 4 [(google.api.field_behavior) = OPTIONAL];
-        }
-        // Subinterface Settings
-        repeated Subinterface subinterface = 2 [(google.api.field_behavior) = OPTIONAL];
+    // Hold State Settings - ro
+    message HoldState {
+      // Hold state up
+      uint32 up = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+      // Hold state down
+      uint32 down = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
     }
-    // Subinterfaces assigned to the interface
-    Subinterfaces subinterfaces = 5 [(google.api.field_behavior) = OPTIONAL];
+    // Hold State Settings
+    HoldState hold_state = 2 [(google.api.field_behavior) = OUTPUT_ONLY];
+  }
+  // Hold Time Settings
+  HoldTime holdtime = 4 [(google.api.field_behavior) = OPTIONAL];
 
-    // Ethernet interface
-    EthernetInterface ethernet = 6 [(google.api.field_behavior) = OPTIONAL];
+  // Subinterfaces settings - VLAN, etc.
+  message Subinterfaces {
+    // Subinterface settings
+    message Subinterface {
+      // Subinterface index
+      int64 index = 1 [(google.api.field_behavior) = OPTIONAL];
+
+      // Subinterface configuration
+      message SubifConfig {
+        // Subinterface Index
+        uint64 index = 1 [(google.api.field_behavior) = OPTIONAL];
+        // Subinterface description
+        string description = 2 [(google.api.field_behavior) = OPTIONAL];
+        // Subinterface enabled
+        bool enabled = 3 [(google.api.field_behavior) = OPTIONAL];
+      }
+      // Subinterface Configuration
+      SubifConfig subif_config = 2 [(google.api.field_behavior) = OPTIONAL];
+
+      // Subinterface State and Statistics
+      NetInterfaceState state = 3 [(google.api.field_behavior) = OUTPUT_ONLY];
+
+      // Subinterface VLAN
+      VlanIf vlan = 4 [(google.api.field_behavior) = OPTIONAL];
+    }
+    // Subinterface Settings
+    repeated Subinterface subinterface = 2 [(google.api.field_behavior) = OPTIONAL];
+  }
+  // Subinterfaces assigned to the interface
+  Subinterfaces subinterfaces = 5 [(google.api.field_behavior) = OPTIONAL];
+
+  // Ethernet interface
+  EthernetInterface ethernet = 6 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Get Interface Request
 message GetNetInterfaceRequest {
-    // Name of interface requested
-    string name = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1/Interfaces"
-    ];
+  // Name of interface requested
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1/Interfaces"
+  ];
 }
 
 // List Interfaces Request
 message ListNetInterfacesRequest {
-    // parent
-    string parent = 1 [
-        (google.api.field_behavior) = REQUIRED,
-        (google.api.resource_reference).type = "opi_api.network.v1/Interfaces"
-    ];
-    // page size
-    int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
-    // page token
-    string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
+  // parent
+  string parent = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "opi_api.network.v1/Interfaces"
+  ];
+  // page size
+  int32 page_size = 2 [(google.api.field_behavior) = OPTIONAL];
+  // page token
+  string page_token = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // List of Interfaces Response
 message ListNetInterfacesResponse {
-    // List of interfaces
-    repeated NetInterface net_interfaces = 1;
-    // next page token
-    string next_page_token = 2;
+  // List of interfaces
+  repeated NetInterface net_interfaces = 1;
+  // next page token
+  string next_page_token = 2;
 }
 
 // Update Interface Request
 message UpdateNetInterfaceRequest {
-    // Interface update settings
-    NetInterface net_interface = 1 [(google.api.field_behavior) = REQUIRED];
-    // list of fields to update
-    google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
-    // If set to true, and the object is not found, a new object will be created. 
-    // In this situation, 'update_mask' is ignored. 
-    bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
+  // Interface update settings
+  NetInterface net_interface = 1 [(google.api.field_behavior) = REQUIRED];
+  // list of fields to update
+  google.protobuf.FieldMask update_mask = 2 [(google.api.field_behavior) = OPTIONAL];
+  // If set to true, and the object is not found, a new object will be created.
+  // In this situation, 'update_mask' is ignored.
+  bool allow_missing = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 // Interface Types Enumeration
 enum InterfaceType {
-    // Interface Unspecified
-    INTERFACE_TYPE_UNSPECIFIED = 0;
-    // Ethernet Interface
-    INTERFACE_TYPE_ETHERNET = 1;
-    // Loopback Interface
-    INTERFACE_TYPE_LOOPBACK = 2;
+  // Interface Unspecified
+  INTERFACE_TYPE_UNSPECIFIED = 0;
+  // Ethernet Interface
+  INTERFACE_TYPE_ETHERNET = 1;
+  // Loopback Interface
+  INTERFACE_TYPE_LOOPBACK = 2;
 }
 
 // Operational State Enumeration
 enum OperState {
-    // Unspecified
-    OPER_STATE_UNSPECIFIED = 0;
-    // Operational Up
-    OPER_STATE_UP = 2;
-    // Operational Down
-    OPER_STATE_DOWN = 3;
-    // Operational Testing
-    OPER_STATE_TESTING = 4;
-    // Unknown
-    OPER_STATE_UNKNOWN = 5;
-    // Dormant
-    OPER_STATE_DORMANT = 6;
-    // Not Present
-    OPER_STATE_NOT_PRESENT = 7;
-    // Lower Layer Down
-    OPER_STATE_LOWER_LAYER_DOWN = 8;
+  // Unspecified
+  OPER_STATE_UNSPECIFIED = 0;
+  // Operational Up
+  OPER_STATE_UP = 2;
+  // Operational Down
+  OPER_STATE_DOWN = 3;
+  // Operational Testing
+  OPER_STATE_TESTING = 4;
+  // Unknown
+  OPER_STATE_UNKNOWN = 5;
+  // Dormant
+  OPER_STATE_DORMANT = 6;
+  // Not Present
+  OPER_STATE_NOT_PRESENT = 7;
+  // Lower Layer Down
+  OPER_STATE_LOWER_LAYER_DOWN = 8;
 }

--- a/network/opinetcommon/networktypes.proto
+++ b/network/opinetcommon/networktypes.proto
@@ -3,11 +3,10 @@
 syntax = "proto3";
 package opi_api.network.opinetcommon.v1alpha1;
 
-option java_package = "opi_api.network.opinetcommon.v1alpha1";
+option go_package = "github.com/opiproject/opi-api/network/opinetcommon/v1alpha1/gen/go";
 option java_multiple_files = true;
 option java_outer_classname = "NetworkTypesProto";
-
-option go_package = "github.com/opiproject/opi-api/network/opinetcommon/v1alpha1/gen/go";
+option java_package = "opi_api.network.opinetcommon.v1alpha1";
 
 // IP Address object
 message IPAddress {
@@ -20,7 +19,7 @@ message IPAddress {
     //     aip.dev/not-precedent: must use fixed32 --)
     fixed32 v4_addr = 2;
     // IPv6 address
-    bytes  v6_addr = 3;
+    bytes v6_addr = 3;
   }
 }
 
@@ -54,28 +53,28 @@ message IPv6Prefix {
 message EncapVal {
   oneof val {
     // vlan id for DOT1Q
-    int32  vlan_id  = 1;
+    int32 vlan_id = 1;
     // MPLS tag/slot for MPLS over UDP
-    int32  mpls_tag = 2;
+    int32 mpls_tag = 2;
     // VXLAN VNID (24bit value)
-    int32  vnid     = 3;
+    int32 vnid = 3;
     // NVGRE VSID
-    int32  vsid     = 5;
+    int32 vsid = 5;
   }
 }
 
 // fabric encap
 message Encap {
   // encyp type
-  EncapType type  = 1;
+  EncapType type = 1;
   // encap value
-  EncapVal  value = 2;
+  EncapVal value = 2;
 }
 
 // PortRange object has low and high end of the port ranges
 message PortRange {
   // range:0-65535
-  int32 port_low  = 1;
+  int32 port_low = 1;
   // range:0-65535
   int32 port_high = 2;
 }
@@ -83,7 +82,7 @@ message PortRange {
 // IP Range
 message IPRange {
   // starting IP address
-  IPAddress low  = 1;
+  IPAddress low = 1;
   // ending IP address
   IPAddress high = 2;
 }
@@ -112,7 +111,7 @@ message IPEntry {
 
 // IPList is a list of IPEntry objects
 message IPList {
-   // list of ip entries (prefix, range)
+  // list of ip entries (prefix, range)
   repeated IPEntry ip_entries = 1;
 }
 
@@ -191,11 +190,11 @@ message ICMPMatchList {
 message RuleL4Match {
   oneof l4info {
     // source and/or destination ports/ranges
-    PortMatch     ports           = 1;
+    PortMatch ports = 1;
     // ICMP type/code match criteria
-    ICMPMatch     type_code       = 2;
+    ICMPMatch type_code = 2;
     // list of source and/or destination ports/ranges
-    PortListMatch port_list       = 3;
+    PortListMatch port_list = 3;
     // list ICMP type/code match criteria
     ICMPMatchList icmp_match_list = 4;
   }
@@ -222,11 +221,11 @@ enum SecurityRuleAction {
   // no action
   // (-- api-linter: core::0126::unspecified=disabled
   //     aip.dev/not-precedent: NONE means no action. --)
-  SECURITY_RULE_ACTION_NONE  = 0;
+  SECURITY_RULE_ACTION_NONE = 0;
   // allow
   SECURITY_RULE_ACTION_ALLOW = 1;
   // deny
-  SECURITY_RULE_ACTION_DENY  = 2;
+  SECURITY_RULE_ACTION_DENY = 2;
 }
 
 // IP address families
@@ -234,23 +233,23 @@ enum IpAf {
   // unspecified
   IP_AF_UNSPECIFIED = 0;
   // ipv4
-  IP_AF_INET        = 1;
+  IP_AF_INET = 1;
   // ipv6
-  IP_AF_INET6       = 2;
+  IP_AF_INET6 = 2;
 }
 
 // encap types in the network
 enum EncapType {
   // no encap
-  ENCAP_TYPE_UNSPECIFIED   = 0;
+  ENCAP_TYPE_UNSPECIFIED = 0;
   // 802.1q
-  ENCAP_TYPE_DOT1Q         = 1;
+  ENCAP_TYPE_DOT1Q = 1;
   // MPLS over UDP
   ENCAP_TYPE_MPLS_OVER_UDP = 2;
   // VXLAN
-  ENCAP_TYPE_VXLAN         = 3;
+  ENCAP_TYPE_VXLAN = 3;
   // NVGRE
-  ENCAP_TYPE_NVGRE         = 4;
+  ENCAP_TYPE_NVGRE = 4;
 }
 
 // route type
@@ -258,13 +257,13 @@ enum RouteType {
   // unspecified
   ROUTE_TYPE_UNSPECIFIED = 0;
   // other
-  ROUTE_TYPE_OTHER       = 1;
+  ROUTE_TYPE_OTHER = 1;
   // reject
-  ROUTE_TYPE_REJECT      = 2;
+  ROUTE_TYPE_REJECT = 2;
   // local
-  ROUTE_TYPE_LOCAL       = 3;
+  ROUTE_TYPE_LOCAL = 3;
   // remote
-  ROUTE_TYPE_REMOTE      = 4;
+  ROUTE_TYPE_REMOTE = 4;
 }
 
 // route protocols
@@ -272,11 +271,11 @@ enum RouteProtocol {
   // unspecified
   ROUTE_PROTOCOL_UNSPECIFIED = 0;
   // local
-  ROUTE_PROTOCOL_LOCAL       = 1;
+  ROUTE_PROTOCOL_LOCAL = 1;
   // static
-  ROUTE_PROTOCOL_STATIC      = 2;
+  ROUTE_PROTOCOL_STATIC = 2;
   // bgp (dynamic)
-  ROUTE_PROTOCOL_BGP         = 3;
+  ROUTE_PROTOCOL_BGP = 3;
 }
 
 // admin state of control plane objects
@@ -284,11 +283,11 @@ enum AdminState {
   // unspecified
   ADMIN_STATE_UNSPECIFIED = 0;
   // enable
-  ADMIN_STATE_ENABLE      = 1;
+  ADMIN_STATE_ENABLE = 1;
   // disable
-  ADMIN_STATE_DISABLE     = 2;
+  ADMIN_STATE_DISABLE = 2;
   // testing
-  ADMIN_STATE_TESTING     = 3;
+  ADMIN_STATE_TESTING = 3;
 }
 
 // direction in which policy is enforced
@@ -298,9 +297,9 @@ enum PolicyDir {
   // unspecified
   POLICY_DIR_UNSPECIFIED = 0;
   // ingress (towards vnic from network)
-  POLICY_DIR_INGRESS     = 1;
+  POLICY_DIR_INGRESS = 1;
   // egress (from vnic to network)
-  POLICY_DIR_EGRESS      = 2;
+  POLICY_DIR_EGRESS = 2;
 }
 
 // WildcardMatch options
@@ -310,5 +309,5 @@ enum WildcardMatch {
   //     aip.dev/not-precedent: NONE means don't match anything. --)
   WILDCARD_MATCH_NONE = 0;
   // match everything
-  WILDCARD_MATCH_ANY  = 256;
+  WILDCARD_MATCH_ANY = 256;
 }

--- a/network/opinetcommon/networkvlan.proto
+++ b/network/opinetcommon/networkvlan.proto
@@ -2,165 +2,163 @@
 // Copyright (c) 2024 Dell Inc, or its subsidiaries.
 //
 // Derived from the OpenConfig interfaces model github.com/openconfig/public/release/models/vlan
-// 
+//
 // (-- api-linter: core::0141::forbidden-types=disabled
 //     aip.dev/not-precedent: counters, mtu, index must be uint and not int. --)
 syntax = "proto3";
 
 package opi_api.network.opinetcommon.v1alpha1;
 
-option java_package = "opi_api.network.opinetcommon.v1alpha1";
+option go_package = "github.com/opiproject/opi-api/network/opinetcommon/v1alpha1/gen/go";
 option java_multiple_files = true;
 option java_outer_classname = "NetworkVlanProto";
-
-option go_package = "github.com/opiproject/opi-api/network/opinetcommon/v1alpha1/gen/go";
+option java_package = "opi_api.network.opinetcommon.v1alpha1";
 
 // Switched VLAN Configuration Settings that are part of the Ethernet interface
 message SwitchedVlanSetting {
-    // Setting for the VLAN interface to access or trunk mode
-    VlanIfMode vlan_interface_mode = 1;
-    // VLAN ID when the mode is set to trunk mode
-    uint32 native_vlan = 2;
-    // VLAN ID when the mode is set to access mode
-    uint32 access_vlan = 3;
-    // Allowed VLANs may be specified for trunk mode interfaces
-    string trunk_vlans = 4;
+  // Setting for the VLAN interface to access or trunk mode
+  VlanIfMode vlan_interface_mode = 1;
+  // VLAN ID when the mode is set to trunk mode
+  uint32 native_vlan = 2;
+  // VLAN ID when the mode is set to access mode
+  uint32 access_vlan = 3;
+  // Allowed VLANs may be specified for trunk mode interfaces
+  string trunk_vlans = 4;
 }
 
 // VLAN settings associated with the Ethernet Interface
 message VlanSwitchedIf {
-    // Configuration parameters for VLAN
-    SwitchedVlanSetting config = 1;
-    // State variables for VLAN
-    SwitchedVlanSetting state = 2;
+  // Configuration parameters for VLAN
+  SwitchedVlanSetting config = 1;
+  // State variables for VLAN
+  SwitchedVlanSetting state = 2;
 }
 
 // VLAN Ingress and Egress Settings
 message VlanIngressEgressSetting {
-    // VLAN stack behaviors for packets that arrive or are transmitted on
-    // this subinterface after their VLAN idenitifer(s) have been matched
-    VlanStackAction vlanstackaction = 1;
-    // VLAN identifier - (1-4094) and will utilize 16 bits max
-    uint32 vlan_id = 2;
-    // The tag protocol identifier field (TPID) that is used by the action
-    // configured by 'vlan-stack-action' when modifying the VLAN stack.
-    TpidTypes tpid = 3;
+  // VLAN stack behaviors for packets that arrive or are transmitted on
+  // this subinterface after their VLAN idenitifer(s) have been matched
+  VlanStackAction vlanstackaction = 1;
+  // VLAN identifier - (1-4094) and will utilize 16 bits max
+  uint32 vlan_id = 2;
+  // The tag protocol identifier field (TPID) that is used by the action
+  // configured by 'vlan-stack-action' when modifying the VLAN stack.
+  TpidTypes tpid = 3;
 }
 
 // VLAN Interface Configuration
 message VlanIf {
-    // Configuration for VLAN tag matching schemes
-    message VlanMatch {
-        // Single Tagged matching of exact VLAN identifier
-        message SingleTagged {
-            // Configuration for matching single-tagged packets with an exact
-            // VLAN identifier
-            message SingleTagConfig {
-                // Single tag VLAN Identifier (1-4094)
-                uint32 vlan_id = 1;
-            } 
-            // Configuration for exact matching of single tagged packets
-            SingleTagConfig config = 1;
+  // Configuration for VLAN tag matching schemes
+  message VlanMatch {
+    // Single Tagged matching of exact VLAN identifier
+    message SingleTagged {
+      // Configuration for matching single-tagged packets with an exact
+      // VLAN identifier
+      message SingleTagConfig {
+        // Single tag VLAN Identifier (1-4094)
+        uint32 vlan_id = 1;
+      }
+      // Configuration for exact matching of single tagged packets
+      SingleTagConfig config = 1;
 
-            // State for matching single-tagged packets with an exact VLAN
-            message SingleTagState {
-                // Single tag VLAN Identifier configured (1-4094)
-                uint32 vlan_id = 1;
-            } 
-            // State for exact matching of single tagged packets
-            SingleTagState state = 2;
-        } 
-        // Single tagged VLAN exact matching
-        SingleTagged singletagged = 1;
-
-        // Single tagged list matching configuration
-        message SingleTaggedList {
-            // Configuration for matching single-tagged packets with a list of
-            // VLAN identifiers
-            message TagListConfig {
-                // List of VLAN identifiers for single-tagged packets
-                repeated uint32 vlan_id = 1;
-            }
-            // Configuration for single tagged VLAN list 
-            TagListConfig config = 1;
-
-            // State for matching single-tagged packets with a list of VLAN
-            // identifiers
-            message TagListStatus {
-                // List of VLAN identifiers configured for single-tagged packets
-                repeated uint32 vlanid = 1;
-            }
-            // State for sintle tagged list
-            TagListStatus status = 2;
-        }
-        // Single tag list VLAN matching
-        SingleTaggedList singletaggedlist = 2;
-    
-    } 
-    // VLAN Tag matching schemes
-    VlanMatch match = 1;
-
-    // Ingress VLAN stack behaviors for packets that arrive on this subinterface
-    // after their VLAN idenitifer(s) have been matched
-    message VlanIngressMapping {
-        // Configuration for ingress VLAN and label behaviors for packets that
-        // arrive on this subinterface
-        VlanIngressEgressSetting config = 1;
-        // State for ingress VLAN and label behaviors for packets that arrive
-        // on this subinterface
-        VlanIngressEgressSetting state = 2;
+      // State for matching single-tagged packets with an exact VLAN
+      message SingleTagState {
+        // Single tag VLAN Identifier configured (1-4094)
+        uint32 vlan_id = 1;
+      }
+      // State for exact matching of single tagged packets
+      SingleTagState state = 2;
     }
-    // Ingress VLAN stack behaviors after received packets have matched
-    VlanIngressMapping ingressmapping = 2;
+    // Single tagged VLAN exact matching
+    SingleTagged singletagged = 1;
 
-    // Egress VLAN stack behaviors for packets that are destined for output via
-    // this subinterface
-    message VlanEgressMapping {
-        // Configuration for egress VLAN stack behaviors for packets that are
-        // destined for output via this subinterface
-        VlanIngressEgressSetting config = 1;
-        // State for engress VLAN stack behaviors for packets that are destined
-        // for output via this subinterface
-        VlanIngressEgressSetting state = 2;
-    } 
-    // Egress VLAN stack behaviors for output packets
-    VlanEgressMapping egressmapping = 3;
+    // Single tagged list matching configuration
+    message SingleTaggedList {
+      // Configuration for matching single-tagged packets with a list of
+      // VLAN identifiers
+      message TagListConfig {
+        // List of VLAN identifiers for single-tagged packets
+        repeated uint32 vlan_id = 1;
+      }
+      // Configuration for single tagged VLAN list
+      TagListConfig config = 1;
+
+      // State for matching single-tagged packets with a list of VLAN
+      // identifiers
+      message TagListStatus {
+        // List of VLAN identifiers configured for single-tagged packets
+        repeated uint32 vlanid = 1;
+      }
+      // State for sintle tagged list
+      TagListStatus status = 2;
+    }
+    // Single tag list VLAN matching
+    SingleTaggedList singletaggedlist = 2;
+  }
+  // VLAN Tag matching schemes
+  VlanMatch match = 1;
+
+  // Ingress VLAN stack behaviors for packets that arrive on this subinterface
+  // after their VLAN idenitifer(s) have been matched
+  message VlanIngressMapping {
+    // Configuration for ingress VLAN and label behaviors for packets that
+    // arrive on this subinterface
+    VlanIngressEgressSetting config = 1;
+    // State for ingress VLAN and label behaviors for packets that arrive
+    // on this subinterface
+    VlanIngressEgressSetting state = 2;
+  }
+  // Ingress VLAN stack behaviors after received packets have matched
+  VlanIngressMapping ingressmapping = 2;
+
+  // Egress VLAN stack behaviors for packets that are destined for output via
+  // this subinterface
+  message VlanEgressMapping {
+    // Configuration for egress VLAN stack behaviors for packets that are
+    // destined for output via this subinterface
+    VlanIngressEgressSetting config = 1;
+    // State for engress VLAN stack behaviors for packets that are destined
+    // for output via this subinterface
+    VlanIngressEgressSetting state = 2;
+  }
+  // Egress VLAN stack behaviors for output packets
+  VlanEgressMapping egressmapping = 3;
 }
 
 // Tag Protocol Identifier (TPID) Types Enumeration
 enum TpidTypes {
-    // Unspecified
-    TPID_TYPES_UNSPECIFIED = 0;
-    // Default value for 802.1q single-tagged VLANs
-    TPID_TYPES_0X8100 = 1;
-    // Value for 802.1ad provider bridging, QinQ, or stacked VLANs
-    TPID_TYPES_0X88A8 = 2;
-    // Alternate TPID value
-    TPID_TYPES_0X9100 = 3;
-    // Alternate TPID value
-    TPID_TYPES_0X9200 = 4;
-    // Any - Wildcard that matches any of the singly or multiply tagged VLANS
-    TPID_TYPES_ANY = 5;
+  // Unspecified
+  TPID_TYPES_UNSPECIFIED = 0;
+  // Default value for 802.1q single-tagged VLANs
+  TPID_TYPES_0X8100 = 1;
+  // Value for 802.1ad provider bridging, QinQ, or stacked VLANs
+  TPID_TYPES_0X88A8 = 2;
+  // Alternate TPID value
+  TPID_TYPES_0X9100 = 3;
+  // Alternate TPID value
+  TPID_TYPES_0X9200 = 4;
+  // Any - Wildcard that matches any of the singly or multiply tagged VLANS
+  TPID_TYPES_ANY = 5;
 }
 
 // Vlan Stack Action to be performed on the VLAN stack
 enum VlanStackAction {
-    // No action to perform on the VLAN Stack
-    VLAN_STACK_ACTION_UNSPECIFIED = 0;
-    // PUSH a VLAN onto the VLAN Stack
-    VLAN_STACK_ACTION_PUSH = 1;
-    // POP a VLAN from the VLAN Stack
-    VLAN_STACK_ACTION_POP = 2;
-    // SWAP the VLAN at the top of the VLAN Stack
-    VLAN_STACK_ACTION_SWAP = 3;
+  // No action to perform on the VLAN Stack
+  VLAN_STACK_ACTION_UNSPECIFIED = 0;
+  // PUSH a VLAN onto the VLAN Stack
+  VLAN_STACK_ACTION_PUSH = 1;
+  // POP a VLAN from the VLAN Stack
+  VLAN_STACK_ACTION_POP = 2;
+  // SWAP the VLAN at the top of the VLAN Stack
+  VLAN_STACK_ACTION_SWAP = 3;
 }
 
 // VLAN Interface Mode
 enum VlanIfMode {
-    // Interface Mode Unspecified
-    VLAN_IF_MODE_UNSPECIFIED = 0;
-    // Interface mode ACCESS
-    VLAN_IF_MODE_ACCESS = 1;
-    // Interface mode TRUNK
-    VLAN_IF_MODE_TRUNK = 2;
+  // Interface Mode Unspecified
+  VLAN_IF_MODE_UNSPECIFIED = 0;
+  // Interface mode ACCESS
+  VLAN_IF_MODE_ACCESS = 1;
+  // Interface mode TRUNK
+  VLAN_IF_MODE_TRUNK = 2;
 }

--- a/network/telco/telco.proto
+++ b/network/telco/telco.proto
@@ -4,8 +4,7 @@
 syntax = "proto3";
 package opi_api.network.telco.v1alpha1;
 
-option java_package = "opi_api.network.telco.v1alpha1";
+option go_package = "github.com/opiproject/opi-api/network/telco/v1alpha1/gen/go";
 option java_multiple_files = true;
 option java_outer_classname = "TelcoProto";
-
-option go_package = "github.com/opiproject/opi-api/network/telco/v1alpha1/gen/go";
+option java_package = "opi_api.network.telco.v1alpha1";

--- a/security/opi_ipsec.proto
+++ b/security/opi_ipsec.proto
@@ -24,7 +24,6 @@ import "google/api/resource.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
-
 import "network/opinetcommon/networktypes.proto";
 
 option go_package = "github.com/opiproject/opi-api/security/v1alpha1/gen/go";
@@ -54,23 +53,17 @@ service IkePeerService {
   }
   // Delete an existing IKE peer specification.
   rpc DeleteIkePeer(DeleteIkePeerRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      delete: "/v1alpha1/{name=ikePeers/*}"
-    };
+    option (google.api.http) = {delete: "/v1alpha1/{name=ikePeers/*}"};
     option (google.api.method_signature) = "name";
   }
   // Get an existing IKE peer specification.
   rpc GetIkePeer(GetIkePeerRequest) returns (IkePeer) {
-    option (google.api.http) = {
-      get: "/v1alpha1/{name=ikePeers/*}"
-    };
+    option (google.api.http) = {get: "/v1alpha1/{name=ikePeers/*}"};
     option (google.api.method_signature) = "name";
   }
   // List existing IKE peers.
   rpc ListIkePeers(ListIkePeersRequest) returns (ListIkePeersResponse) {
-    option (google.api.http) = {
-      get: "/v1alpha1/ikePeers"
-    };
+    option (google.api.http) = {get: "/v1alpha1/ikePeers"};
   }
 }
 
@@ -100,29 +93,21 @@ service IkeConnectionService {
   }
   // Delete an existing IKE connection.
   rpc DeleteIkeConnection(DeleteIkeConnectionRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      delete: "/v1alpha1/{name=ikeConnections/*}"
-    };
+    option (google.api.http) = {delete: "/v1alpha1/{name=ikeConnections/*}"};
     option (google.api.method_signature) = "name";
   }
   // Retrieve an IKE connection.
   rpc GetIkeConnection(GetIkeConnectionRequest) returns (IkeConnection) {
-    option (google.api.http) = {
-      get: "/v1alpha1/{name=ikeConnections/*}"
-    };
+    option (google.api.http) = {get: "/v1alpha1/{name=ikeConnections/*}"};
     option (google.api.method_signature) = "name";
   }
   // List existing IKE connections.
   rpc ListIkeConnections(ListIkeConnectionsRequest) returns (ListIkeConnectionsResponse) {
-    option (google.api.http) = {
-      get: "/v1alpha1/ikeConnections"
-    };
+    option (google.api.http) = {get: "/v1alpha1/ikeConnections"};
   }
   // Get IKE connection statistics.
   rpc StatsIkeConnections(StatsIkeConnectionsRequest) returns (StatsIkeConnectionsResponse) {
-    option (google.api.http) = {
-      get: "/v1alpha1/ikeConnections:stats"
-    };
+    option (google.api.http) = {get: "/v1alpha1/ikeConnections:stats"};
   }
 }
 
@@ -148,25 +133,19 @@ service IpsecSaService {
   }
   // Delete an existing IPsec Security Association
   rpc DeleteIpsecSa(DeleteIpsecSaRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      delete: "/v1alpha1/{name=ipsecSas/*}"
-    };
+    option (google.api.http) = {delete: "/v1alpha1/{name=ipsecSas/*}"};
     option (google.api.method_signature) = "name";
   }
   // Get an IPsec Security Association
   rpc GetIpsecSa(GetIpsecSaRequest) returns (IpsecSa) {
-    option (google.api.http) = {
-      get: "/v1alpha1/{name=ipsecSas/*}"
-    };
+    option (google.api.http) = {get: "/v1alpha1/{name=ipsecSas/*}"};
     option (google.api.method_signature) = "name";
   }
   // List existing IPsec Security Associations
   rpc ListIpsecSas(ListIpsecSasRequest) returns (ListIpsecSasResponse) {
-    option (google.api.http) = {
-      get: "/v1alpha1/ipsecSas"
-    };
+    option (google.api.http) = {get: "/v1alpha1/ipsecSas"};
   }
-} 
+}
 
 // Management of the IPsec Security Policy Database (SPD). The SPD contains
 // information about the IPsec policies that are used to protect the traffic
@@ -190,23 +169,17 @@ service IpsecPolicyService {
   }
   // Delete an existing IPsec Policy
   rpc DeleteIpsecPolicy(DeleteIpsecPolicyRequest) returns (google.protobuf.Empty) {
-    option (google.api.http) = {
-      delete: "/v1alpha1/{name=ipsecPolicies/*}"
-    };
+    option (google.api.http) = {delete: "/v1alpha1/{name=ipsecPolicies/*}"};
     option (google.api.method_signature) = "name";
   }
   // Get an IPsec Policy
   rpc GetIpsecPolicy(GetIpsecPolicyRequest) returns (IpsecPolicy) {
-    option (google.api.http) = {
-      get: "/v1alpha1/{name=ipsecPolicies/*}"
-    };
+    option (google.api.http) = {get: "/v1alpha1/{name=ipsecPolicies/*}"};
     option (google.api.method_signature) = "name";
   }
   // List existing IPsec Policies
   rpc ListIpsecPolicies(ListIpsecPoliciesRequest) returns (ListIpsecPoliciesResponse) {
-    option (google.api.http) = {
-      get: "/v1alpha1/ipsecPolicies"
-    };
+    option (google.api.http) = {get: "/v1alpha1/ipsecPolicies"};
   }
 }
 
@@ -263,7 +236,7 @@ message IkeConnection {
     singular: "ikeConnection"
     plural: "ikeConnections"
   };
-  
+
   // Unique name to identify the connection.
   string name = 1 [(google.api.field_behavior) = IDENTIFIER];
   // IKE/IPsec connection startup behavior. Default: AUTO_STARTUP_MODE_ADD
@@ -287,11 +260,13 @@ message IkeConnection {
   // Local peer name.
   string local = 11 [
     (google.api.field_behavior) = OPTIONAL,
-    (google.api.resource_reference).type = "IkePeer"];
+    (google.api.resource_reference).type = "IkePeer"
+  ];
   // Remote peer name.
   string remote = 12 [
     (google.api.field_behavior) = OPTIONAL,
-    (google.api.resource_reference).type = "IkePeer"];
+    (google.api.resource_reference).type = "IkePeer"
+  ];
   // Configuration information about the encapsulation that should be used when
   // NAT traversal is required. No encapsulation is used if this field is not
   // specified.
@@ -306,7 +281,8 @@ message IkeConnection {
   // IPsec policies that apply to the connection
   repeated string policies = 17 [
     (google.api.field_behavior) = OPTIONAL,
-    (google.api.resource_reference).type = "IpsecPolicy"];
+    (google.api.resource_reference).type = "IpsecPolicy"
+  ];
   // Connection state / status
   IkeConnectionState state = 18 [(google.api.field_behavior) = OUTPUT_ONLY];
 }
@@ -675,7 +651,7 @@ message IkePeer {
 
 // Create an IKE Peer
 message CreateIkePeerRequest {
-  // The ID to use for the IKE Peer. 
+  // The ID to use for the IKE Peer.
   string ike_peer_id = 1 [(google.api.field_behavior) = REQUIRED];
   // The IKE Peer to create.
   IkePeer ike_peer = 2 [(google.api.field_behavior) = REQUIRED];
@@ -694,7 +670,8 @@ message DeleteIkePeerRequest {
   // Name of the IKE peer to delete
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "IkePeer"];
+    (google.api.resource_reference).type = "IkePeer"
+  ];
 }
 
 // Get an IKE Peer
@@ -702,7 +679,8 @@ message GetIkePeerRequest {
   // Name of the IKE peer to retrieve
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "IkePeer"];
+    (google.api.resource_reference).type = "IkePeer"
+  ];
 }
 
 // List IKE Peers
@@ -718,7 +696,7 @@ message ListIkePeersRequest {
 message ListIkePeersResponse {
   // List of IKE peers
   repeated IkePeer ike_peers = 1;
-  
+
   // A token that can be sent as `page_token` to retrieve the next page.
   // If this field is omitted, there are not subsequent pages.
   string next_page_token = 2;
@@ -728,7 +706,7 @@ message ListIkePeersResponse {
 message CreateIkeConnectionRequest {
   // The ID to use for the IKE Connection.
   string ike_connection_id = 1 [(google.api.field_behavior) = REQUIRED];
-  
+
   // The IKE Connection to create.
   IkeConnection ike_connection = 2 [(google.api.field_behavior) = REQUIRED];
 }
@@ -746,7 +724,8 @@ message DeleteIkeConnectionRequest {
   // Connection name identifying the IKE connection to delete
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "IkeConnection"];
+    (google.api.resource_reference).type = "IkeConnection"
+  ];
 }
 
 // Get an IKE Connection
@@ -754,7 +733,8 @@ message GetIkeConnectionRequest {
   // Connection name identifying the IKE connection to retrieve
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "IkeConnection"];
+    (google.api.resource_reference).type = "IkeConnection"
+  ];
 }
 
 // List IKE Connections
@@ -770,15 +750,14 @@ message ListIkeConnectionsRequest {
 message ListIkeConnectionsResponse {
   // List of IKE connections
   repeated IkeConnection ike_connections = 1;
-  
+
   // A token that can be sent as `page_token` to retrieve the next page.
   // If this field is omitted, there are not subsequent pages.
   string next_page_token = 2;
 }
 
 // Request to get IKE Connection statistics
-message StatsIkeConnectionsRequest {
-}
+message StatsIkeConnectionsRequest {}
 
 // Response to a StatsIkeConnectionsRequest
 message StatsIkeConnectionsResponse {
@@ -799,7 +778,7 @@ message ListIpsecSasRequest {
 message ListIpsecSasResponse {
   // List of IPsec SAs
   repeated IpsecSa ipsec_sas = 1;
-  
+
   // A token that can be sent as `page_token` to retrieve the next page.
   // If this field is omitted, there are not subsequent pages.
   string next_page_token = 2;
@@ -810,7 +789,8 @@ message GetIpsecSaRequest {
   // Name of the SA to retrieve
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "IpsecSa"];
+    (google.api.resource_reference).type = "IpsecSa"
+  ];
 }
 
 // Create an IPsec SA
@@ -835,14 +815,15 @@ message DeleteIpsecSaRequest {
   // Name of the SA to delete
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "IpsecSa"];
+    (google.api.resource_reference).type = "IpsecSa"
+  ];
 }
 
 // Create an IPsec Policy
 message CreateIpsecPolicyRequest {
   // The ID to use for the IPsec Policy.
   string ipsec_policy_id = 1 [(google.api.field_behavior) = REQUIRED];
-  
+
   // The IPsec Policy to create.
   IpsecPolicy ipsec_policy = 2 [(google.api.field_behavior) = REQUIRED];
 }
@@ -860,7 +841,8 @@ message DeleteIpsecPolicyRequest {
   // Name of the policy to delete
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "IpsecPolicy"];
+    (google.api.resource_reference).type = "IpsecPolicy"
+  ];
 }
 
 // Get an IPsec Policy
@@ -868,7 +850,8 @@ message GetIpsecPolicyRequest {
   // Name of the policy to retrieve
   string name = 1 [
     (google.api.field_behavior) = REQUIRED,
-    (google.api.resource_reference).type = "IpsecPolicy"];
+    (google.api.resource_reference).type = "IpsecPolicy"
+  ];
 }
 
 // List IPsec Policies
@@ -884,7 +867,7 @@ message ListIpsecPoliciesRequest {
 message ListIpsecPoliciesResponse {
   // List of IPsec policies
   repeated IpsecPolicy ipsec_policies = 1;
-  
+
   // A token that can be sent as `page_token` to retrieve the next page.
   // If this field is omitted, there are not subsequent pages.
   string next_page_token = 2;


### PR DESCRIPTION
Update/refactor the protobuf files for:

cloud
evpn-gw
k8s (placeholder)
opinetcommon
telco (placeholder)
security

The updates are to align with the standard formatting rules for protobuf definitions that the Buf v2 enforces.  The updated can be handled using the "buf format" command.  Example command syntax

- buf format --diff -w  -> this will format all of the protobufs and show the diff changes along with writing the files
- buf format --diff --path ./security  -> this will show a diff of the security protobufs that need to be updated
- buf format --diff -w --path ./security  -> this will show the diff and write the updated protobufs for the security api
- 