### PR TITLE
refactor(buf): add go.mod to inventory api to resolve import into pro…

### DIFF
--- a/v1/gen/go/inventory/go.mod
+++ b/v1/gen/go/inventory/go.mod
@@ -1,0 +1,3 @@
+module github.com/opiproject/sandersms/opi-api/v1/gen/go/inventory
+
+go 1.24.0


### PR DESCRIPTION
With the introduction of the newer versions of golang >1.18 imported modules should have a go.mod file to define the language setting.

When using the generated protobuf files, the bridge code examples were failing with the newly generated files due to predeclared types which required newer versions of go.  If a module doesn't have a go.mod definition with the language setting specified, it will default to 1.16.  Many of the new declarations are not supported in 1.16 and the compile will fail.

Adding a go.mod file to the specific modules is required.  This will be subsequently added to the other module areas in the v1/gen/go folder of the api.